### PR TITLE
Added flaky tests from graphhopper.

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -1503,9 +1503,13 @@ https://github.com/gooddata/GoodData-CL,58728ec3e57ea9a4d689f38b0b385e8724af618c
 https://github.com/google/java-monitoring-client-library,3212364c3e535530c3d96e127c42d302e2c0064b,metrics,com.google.monitoring.metrics.MetricRegistryImplTest.testRegisterAndUnregister_tracksRegistrations,OD-Vic,Opened,https://github.com/google/java-monitoring-client-library/pull/21,
 https://github.com/google/jimfs,ced6093fe69a31e37ba8bbf63858b50c7164f4a4,jimfs,com.google.common.jimfs.JimfsFileChannelTest.testCloseByInterrupt,UD,,,
 https://github.com/googleapis/google-auth-library-java,0a8412fcf9de4ac568b9f88618e44087dd31b144,appengine,com.google.auth.appengine.AppEngineCredentialsTest.warnsDefaultCredentialsWithTransport,OD,,,https://github.com/TestingResearchIllinois/flaky-test-dataset/issues/81
+https://github.com/graphhopper/graphhopper,b65d9413e2dc29b662a1bb2db146b536471167a9,reader-gtfs,com.graphhopper.gtfs.TransfersTest.testInternalTransfersByToRouteIfRouteSpecific,ID,,,
 https://github.com/graphhopper/graphhopper,91f1a89a0b515328109a659e445b1008d9db8769,isochrone,com.graphhopper.isochrone.algorithm.IsochroneTest.testSearch,ID,,,
 https://github.com/graphhopper/graphhopper,91f1a89a0b515328109a659e445b1008d9db8769,core,com.graphhopper.routing.ch.CHProfileSelectorTest.onlyEdgeBasedPresent,ID,,,
 https://github.com/graphhopper/graphhopper,91f1a89a0b515328109a659e445b1008d9db8769,core,com.graphhopper.routing.ch.CHProfileSelectorTest.onlyNodeBasedPresent,ID,,,
+https://github.com/graphhopper/graphhopper,b65d9413e2dc29b662a1bb2db146b536471167a9,core,com.graphhopper.routing.DirectionResolverOnQueryGraphTest.duplicateCoordinatesAtBaseOrAdjNode,ID,,,
+https://github.com/graphhopper/graphhopper,b65d9413e2dc29b662a1bb2db146b536471167a9,core,com.graphhopper.search.StringIndexTest.putDuplicate,ID,,,
+https://github.com/graphhopper/graphhopper,b65d9413e2dc29b662a1bb2db146b536471167a9,core,com.graphhopper.search.StringIndexTest.testLoadKeys,ID,,,
 https://github.com/graphhopper/graphhopper,91f1a89a0b515328109a659e445b1008d9db8769,tools,com.graphhopper.tools.QueryTortureTest.testGetQuery,ID,Rejected,https://github.com/graphhopper/graphhopper/pull/1941,
 https://github.com/graphhopper/graphhopper,91f1a89a0b515328109a659e445b1008d9db8769,web-api,com.graphhopper.util.InstructionListRepresentationTest.testRoundaboutJsonIntegrity,ID,,,
 https://github.com/graphhopper/graphhopper,91f1a89a0b515328109a659e445b1008d9db8769,web-api,com.graphhopper.util.InstructionListRepresentationTest.testRoundaboutJsonNaN,ID,Rejected,https://github.com/graphhopper/graphhopper/pull/1873,


### PR DESCRIPTION
Added 4 flaky tests from ```graphhopper``` using Nondex in full mode. The seed tables are as below.

Test Name| 933178| 974622| 1016066
---|---|---|---
com.graphhopper.routing.DirectionResolverOnQueryGraphTest#duplicateCoordinatesAtBaseOrAdjNode|✖| ✔| ✖
com.graphhopper.search.StringIndexTest#testLoadKeys| ✔| ✖| ✖
com.graphhopper.search.StringIndexTest#putDuplicate| ✖| ✖| ✖
com.graphhopper.gtfs.TransfersTest#testInternalTransfersByToRouteIfRouteSpecific|✖| ✖| ✖