### PR TITLE
Modify Readme in format_checker

### DIFF
--- a/format_checker/README.md
+++ b/format_checker/README.md
@@ -9,7 +9,7 @@
 This tool is recommended to be run using Python 3.9, however Python 3.7 and above should also work. You can check your Python version by typing `python -V` on your command line. For example:
 
 ```
-$ python -V
+python -V
 Python 3.9.4
 ```
 
@@ -20,7 +20,7 @@ If doing that tells you you're working with Python 2.7, you should try `python3 
 The dependencies for this tool can be installed running the following from the root directory:
 
 ```
-$ pip install -r format_checker/requirements.txt
+pip install -r format_checker/requirements.txt
 ```
 
 #### 3. Run the tool
@@ -28,9 +28,9 @@ $ pip install -r format_checker/requirements.txt
 Running this tool locally only requires running `main.py` from the root directory:
 
 ```
-$ python format_checker/main.py
+python format_checker/main.py
 ```
-In case your Python version is 2.7 but your your Python3 version is 3.7 or above (see step 1), you should run it using `python3` instead of `python`. 
+In case your Python version is 2.7 but your your Python3 version is 3.7 or above (see step 1), you should run it using `python3` instead of `python`, and `pip3` instead of `pip`.
 
 This will check all the implemented rules only for the rows of the `.csv` files that have been modified in some way (including row additions). It can check either for uncommitted changes (e.g. if a row was modified in `pr-data.csv` but the file wasn't committed) or for changes made in the commits related to the push/pull request that triggered the GitHub Actions build, as well as for committed changes that haven't yet been pushed. By default, the tool looks for uncommitted changes as well as committed changes every time it is run locally.
 


### PR DESCRIPTION
1.easier to copy cmd when '$' is deleted,
2.add notes: when python version is 2.7, we need to use ```pip3``` to install. I once stuck here for a long time, cuz ```pip install``` did not work.