### PR TITLE
Add RepoArchived check for PR

### DIFF
--- a/format_checker/requirements.txt
+++ b/format_checker/requirements.txt
@@ -1,1 +1,2 @@
 errorhandler==2.0.1
+requests==2.18.4

--- a/format_checker/utils.py
+++ b/format_checker/utils.py
@@ -116,7 +116,26 @@ def log_esp_error(filename, log, message):
     log_esp_error.tracker += 1
     log.error("ERROR: On file " + filename + ": " + message)
 
+    
+def log_archived_error(filename, log, line, row, key):
+    """Logs a archived-related error."""
 
+    # log_archived_error.tracker += 1  # AttributeError: 'function' object has no attribute 'tracker'
+    log_esp_error.tracker += 1
+    log.error(
+        "ERROR: On file "
+        + filename
+        + ", row "
+        + line
+        + ":\n"
+        + "Archived "
+        + key
+        + ': "'
+        + row[key]
+        + '"'
+    )
+    
+    
 def log_warning(filename, log, line, message):
     """Logs a warning."""
 


### PR DESCRIPTION
(a) Changes overview:
- format_checker/common_checks.py 
  - check the archived repo in proposed PR without ```RepoArchived``` status
- format_checker/pr_checker.py
  - check the non-archived repo in proposed PR but with ```RepoArchived``` status
- format_checker/requirements.txt
  - add one dependency
- format_checker/utils.py 
  - add a log function for repo-archived error
 
(b) Some test results showing the changes work by running ```python3 format_checker/main.py```
1. check the archived repo in proposed PR without ```RepoArchived``` status
![image](https://user-images.githubusercontent.com/46290389/144684996-14870d18-ca71-49e1-bb94-7c67b91543d1.png)

2. check the non-archived repo in proposed PR but with ```RepoArchived``` status
![image](https://user-images.githubusercontent.com/46290389/144684991-3bca46f9-be1c-455c-b388-28afe47ed344.png)