### PR TITLE
fix UnicodeEncodeError in showmakedown.py

### DIFF
--- a/auto-run-nondex/showmarkdown.py
+++ b/auto-run-nondex/showmarkdown.py
@@ -14,7 +14,7 @@ while True:
     with open(filename) as f:
         content = f.read()
         report = html2text.html2text(content).replace("|\n", "|")
-        print(report)
+        print(report.encode("utf-8"))
         f_md.write(report + "\n")
         f.close()
     print(filename)


### PR DESCRIPTION
When running `showmakedown.py` separately, I got the following error (this problem is solved):
```
$ python3 showmarkdown.py cxf/.runNondex/htmlOutput 
Traceback (most recent call last): 
    File "C:\Users\XinyuWu\softwareTest\idoft\auto-run-nondex\showmarkdown.py", line 17, in <module> 
        print(report) 
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.1264.0_x64__qbz5n2kfra8p0\lib\encodings\cp1252.py", lin 
    return codecs.charmap_encode(input,self.errors,encoding_table)[0] 
UnicodeEncodeError: 'charmap' codec can't encode character '\u2716' in position 122: character maps to <undefined> 
# X emoji
```
Problem is solved by change line 17 from `print(report)` to `print(report.encode("utf-8"))`. 
