### PR TITLE
Six new flaky tests in : https://github.com/apache/hive ,serde,ecdac363e042200d85bb8b894aa20d91a1642a18

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -1283,7 +1283,12 @@ https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,standalo
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,standalone-metastore/metastore-server,org.apache.hadoop.hive.metastore.TestPartitionManagement.testPartitionRetention,ID,,,
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,standalone-metastore/metastore-server,org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils.testGetPartitionspecsGroupedBySDonePartitionCombined,ID,Rejected,https://github.com/apache/hive/pull/2719,
 https://github.com/apache/hive,54e43339dd671018fc70ebb5d9f0b292d70391a6,itests/serde,org.apache.hadoop.hive.serde2.avro.TestAvroDeserializer.canDeserializeTimestamps,OD,,,
+https://github.com/apache/hive,ecdac363e042200d85bb8b894aa20d91a1642a18,serde,org.apache.hadoop.hive.serde2.binarysortable.TestBinarySortableSerDe.testBinarySortableSerDe,ID,,,
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testHandlingAlteredSchemas,ID,Rejected,https://github.com/apache/hive/pull/923,
+https://github.com/apache/hive,ecdac363e042200d85bb8b894aa20d91a1642a18,serde,org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testLazyBinaryColumnarSerDeWithEmptyBinary,ID,,,
+https://github.com/apache/hive,ecdac363e042200d85bb8b894aa20d91a1642a18,serde,org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDe,ID,,,
+https://github.com/apache/hive,ecdac363e042200d85bb8b894aa20d91a1642a18,serde,org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeEmpties,ID,,,
+https://github.com/apache/hive,ecdac363e042200d85bb8b894aa20d91a1642a18,serde,org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeInnerNulls,ID,,,
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,org.apache.hadoop.hive.serde2.lazy.TestLazySimpleSerDe.testSerDeParameters,ID,,,
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,org.apache.hadoop.hive.serde2.lazybinary.TestLazyBinarySerDe.testLazyBinarySerDe,ID,,,
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,org.apache.hadoop.hive.serde2.lazybinary.TestLazyBinarySerDe2.testLazyBinarySerDe,ID,,,
@@ -1294,6 +1299,7 @@ https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,or
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,org.apache.hadoop.hive.serde2.objectinspector.TestStandardObjectInspectors.testStandardUnionObjectInspector,ID,Accepted,https://github.com/apache/hive/pull/929,
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,org.apache.hadoop.hive.serde2.objectinspector.TestThriftObjectInspectors.testThriftObjectInspectors,ID,,,
 https://github.com/apache/hive,90fa9064f2c6907fbe6237cb46d5937eebd8ea31,serde,org.apache.hadoop.hive.serde2.objectinspector.TestThriftObjectInspectors.testThriftSetObjectInspector,ID,,,
+https://github.com/apache/hive,ecdac363e042200d85bb8b894aa20d91a1642a18,serde,org.apache.hadoop.hive.serde2.TestStatsSerde.testLazyBinarySerDe,ID,,,
 https://github.com/apache/hudi,9c059ef8e574616ceac5595204273244e37fd6a5,hudi-common,org.apache.hudi.common.table.timeline.TestHoodieActiveTimeline.testCreateNewInstantTime,ID,,,
 https://github.com/apache/ignite-3,a1aa7fd4e2398c72827777ec5417d67915ff4da3,modules/cli,org.apache.ignite.cli.commands.cliconfig.CliConfigSubCommandTest.noKey,ID,Accepted,https://github.com/apache/ignite-3/pull/888,The PR was closed but the commit https://github.com/apache/ignite-3/commit/81851d38f6197ea414552148d9db372c09b43eb8 was added to the main branch of the repository
 https://github.com/apache/ignite-3,a1aa7fd4e2398c72827777ec5417d67915ff4da3,modules/cli,org.apache.ignite.cli.deprecated.IgniteCliInterfaceTest$Cluster.initSuccess,ID,Accepted,https://github.com/apache/ignite-3/pull/888,The PR was closed but the commit https://github.com/apache/ignite-3/commit/81851d38f6197ea414552148d9db372c09b43eb8 was added to the main branch of the repository


### PR DESCRIPTION
## Details
* **Six New Failure Tests** with NonDex 1.1.2 on SHA ecdac363e042200d85bb8b894aa20d91a1642a18 【Latest】
* nondexMode=FULL nondexSeed=933178
* nondexMode=FULL nondexSeed=974622
* nondexMode=FULL nondexSeed=1016066

## Specific Tests with test blocks
```
https://github.com/apache/hive ; serde ; ecdac363e042200d85bb8b894aa20d91a1642a18 ; org.apache.hadoop.hive.serde2.TestStatsSerde.testLazyBinarySerDe
https://github.com/apache/hive ; serde ; ecdac363e042200d85bb8b894aa20d91a1642a18 ; org.apache.hadoop.hive.serde2.binarysortable.TestBinarySortableSerDe.testBinarySortableSerDe
https://github.com/apache/hive ; serde ; ecdac363e042200d85bb8b894aa20d91a1642a18 ; org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeEmpties
https://github.com/apache/hive ; serde ; ecdac363e042200d85bb8b894aa20d91a1642a18 ; org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDe
https://github.com/apache/hive ; serde ; ecdac363e042200d85bb8b894aa20d91a1642a18 ; org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testLazyBinaryColumnarSerDeWithEmptyBinary
https://github.com/apache/hive ; serde ; ecdac363e042200d85bb8b894aa20d91a1642a18 ; org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeInnerNulls
```