### PR TITLE
DeveloperFixed test case alluxio.worker.block.BlockLockManagerTest.lockAlreadyReadLockedBlock

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -378,7 +378,7 @@ https://github.com/alien4cloud/alien4cloud,eb57d0feca6c37e0a4aafc3feef494e43e02e
 https://github.com/Alluxio/alluxio,68fcda9dd2ca2181eb897e10ca02fa5bc3a3099f,core/server/worker,alluxio.worker.block.allocator.GreedyAllocatorTest.allocateBlock,ID,,,
 https://github.com/Alluxio/alluxio,68fcda9dd2ca2181eb897e10ca02fa5bc3a3099f,core/server/worker,alluxio.worker.block.allocator.MaxFreeAllocatorTest.allocateBlock,ID,,,
 https://github.com/Alluxio/alluxio,68fcda9dd2ca2181eb897e10ca02fa5bc3a3099f,core/server/worker,alluxio.worker.block.allocator.RoundRobinAllocatorTest.allocateBlock,ID,,,
-https://github.com/Alluxio/alluxio,e6d76803f27133d7700811585f5310470e50e487,core/server/worker,alluxio.worker.block.BlockLockManagerTest.lockAlreadyReadLockedBlock,ID,,,
+https://github.com/Alluxio/alluxio,e6d76803f27133d7700811585f5310470e50e487,core/server/worker,alluxio.worker.block.BlockLockManagerTest.lockAlreadyReadLockedBlock,ID,DeveloperFixed,,https://github.com/Alluxio/alluxio/commit/921a053d0feafc3c831743d1ae996b31d3cc1288
 https://github.com/Alluxio/alluxio,e6d76803f27133d7700811585f5310470e50e487,core/server/worker,alluxio.worker.block.BlockLockManagerTest.lockAlreadyWriteLockedBlock,ID,,,
 https://github.com/Alluxio/alluxio,68fcda9dd2ca2181eb897e10ca02fa5bc3a3099f,core/server/worker,alluxio.worker.block.BlockMetadataViewTest.sameTierView,ID,,,
 https://github.com/Alluxio/alluxio,68fcda9dd2ca2181eb897e10ca02fa5bc3a3099f,core/server/worker,alluxio.worker.block.BlockMetadataViewTest.sameTierViewsBelow,ID,,,


### PR DESCRIPTION
**Flaky Test Details :**
https://github.com/Alluxio/alluxio,e6d76803f27133d7700811585f5310470e50e487,core/server/worker,alluxio.worker.block.BlockLockManagerTest.lockAlreadyReadLockedBlock,ID,,,

**Build Issues :**
```
mvn install -pl core/server/worker -am -DskipTests | tee ../../logs/alluxio.test1.0.log  # Result : Build failed
```

```
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:2.9:check (default) on project alluxio-core-server-worker: Some files do not have the expected license header -> [Help 1]
```

Fixed it using `-Dlicense.skip`

```
mvn install -pl core/server/worker -am -DskipTests -Dlicense.skip | tee ../../logs/alluxio.test1.0.log
```

**Flaky Test Details :**
On the commit mentioned in the pr-data.csv file (e6d76803f27133d7700811585f5310470e50e487), there was a flaky test.

```
mvn -pl core/server/worker test -Dtest=alluxio.worker.block.BlockLockManagerTest#lockAlreadyReadLockedBlock -Dlicense.skip | tee ../../logs/alluxio.test2.log    #### Result : Build passed
```

```
mvn -pl core/server/worker edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=alluxio.worker.block.BlockLockManagerTest#lockAlreadyReadLockedBlock -DnondexRuns=100 -Dlicense.skip=true | tee ../../logs/alluxio.test3.log   #### Result : Build failed
```

Tests in error: 
  `BlockLockManagerTest.lockAlreadyReadLockedBlock:184 » IllegalState Session 1 a...`

However, when I switched to the latest commit on the master branch and found that the test was no longer flaky 

```
git rev-parse HEAD
git checkout 5828d56a824748e7c91076842fad75efb42f92f9
```

```
mvn install -pl core/server/worker -am -DskipTests -Dlicense.skip | tee ../../logs/alluxio.test1.0.log  #### Result : Build passed
````
```
mvn -pl core/server/worker test -Dtest=alluxio.worker.block.BlockLockManagerTest#lockAlreadyReadLockedBlock -Dlicense.skip | tee ../../logs/alluxio.test2.log    #### Result : Build passed
```
```
mvn -pl core/server/worker edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=alluxio.worker.block.BlockLockManagerTest#lockAlreadyReadLockedBlock -DnondexRuns=100 -Dlicense.skip=true | tee ../../logs/alluxio.test3.log   #### Result : Build passed
```

This PR is raised because the Flaky Test is fixed in the latest master. 

The flaky test was fixed in the commit - https://github.com/Alluxio/alluxio/commit/921a053d0feafc3c831743d1ae996b31d3cc1288