### PR TITLE
Update Checker for PR Link and Note

### DIFF
--- a/format_checker/pr_checker.py
+++ b/format_checker/pr_checker.py
@@ -94,16 +94,22 @@ def check_status_consistency(filename, row, i, log):
         else:
             check_pr_link(filename, row, i, log)
 
-    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated"]:
+    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated", "Deleted"]:
 
         # Should contain a note
         if row["Notes"] == "":
-            log_warning(
-                filename,
-                log,
-                i,
-                "Status " + row["Status"] + " should contain a note",
-            )
+            # warning if no note:
+            if row["Status"] in ["InspiredAFix", "Skipped", "Deprecated"]:
+                log_warning(
+                    filename,
+                    log,
+                    i,
+                    "Status " + row["Status"] + " should contain a note",
+                )
+            # error if no note:
+            if row["Status"] in ["MovedOrRenamed", "Deleted"]:
+                log_std_error(filename, log, i, row, "Notes")
+
         # If it contains a note, it should be a valid link
         else:
             check_notes(filename, row, i, log)
@@ -117,9 +123,10 @@ def check_status_consistency(filename, row, i, log):
                     i,
                     "Status " + row["Status"] + " should have a PR Link",
                 )
-            # If it contains a PR link, it should be a valid one
-            else:
-                check_pr_link(filename, row, i, log)
+
+        # If it contains a PR link, it should be a valid one
+        if row["PR Link"] != "":
+            check_pr_link(filename, row, i, log)
 
     if row["Status"] == "" and row["PR Link"] != "":
         check_pr_link(filename, row, i, log)


### PR DESCRIPTION
## Problem

Rows that misplaced Note in PR Link like
```
https://github.com/apache/ignite-3,a1aa7fd4e2398c72827777ec5417d67915ff4da3,modules/storage-api,org.apache.ignite.internal.storage.ConcurrentHashMapStorageTest.testGetAndReplaceClosureIfExistsFalse_entryNotExists,ID,Deleted,https://github.com/apache/ignite-3/commit/68f1dec4cc8fa3fc914ab78802cd50c87637b37a,
```
can pass the auto checker

## Solution

1. If the PR Link isn't empty, then it has to be valid
2. For `Deleted` and `MovedOrRenamed`, have to include a valid Note