### PR TITLE
Fixed 2 flaky tests in wildfly-core cli

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -5198,7 +5198,8 @@ https://github.com/wildfly/wildfly,cb7af61bfbb5615b522cabf8ded9a135178089b7,unde
 https://github.com/wildfly/wildfly,cb7af61bfbb5615b522cabf8ded9a135178089b7,undertow,org.wildfly.extension.undertow.UndertowSubsystem80TestCase.testRuntime,ID,Accepted,https://github.com/wildfly/wildfly/pull/13728,
 https://github.com/wildfly/wildfly,cb7af61bfbb5615b522cabf8ded9a135178089b7,undertow,org.wildfly.extension.undertow.UndertowSubsystem90TestCase.testRuntime,ID,Accepted,https://github.com/wildfly/wildfly/pull/13728,
 https://github.com/wildfly/wildfly,b19048b72669fc0e96665b1b125dc1fda21f5993,undertow,org.wildfly.extension.undertow.UndertowSubsystemTestCase.testRuntime,ID,,,
-https://github.com/wildfly/wildfly-core,b2264f4861f2b0c3de0bd54a29e7fe3365798a87,cli,org.jboss.as.cli.impl.aesh.HelpSupportTestCase.testStandalone,ID,,,
+https://github.com/wildfly/wildfly-core,624b3aa22e4064b42bd171e8d7753238a1d6616c,cli,org.jboss.as.cli.impl.aesh.HelpSupportTestCase.testStandalone,ID,Opened,https://github.com/wildfly/wildfly-core/pull/5366,
+https://github.com/wildfly/wildfly-core,db72abab9b89203891f5c84e0526028dc5f4e9ef,cli,org.jboss.as.cli.impl.BootScriptInvoker.test,ID,Opened,https://github.com/wildfly/wildfly-core/pull/5366,
 https://github.com/wildfly/wildfly-maven-plugin,ba664f977f4a20771eb7aab979164b2fb639a240,core,org.wildfly.plugin.core.DomainDeploymentManagerIT.testDeploy,NOD,,,https://github.com/TestingResearchIllinois/idoft/issues/229
 https://github.com/wildfly/wildfly-maven-plugin,ba664f977f4a20771eb7aab979164b2fb639a240,core,org.wildfly.plugin.core.DomainDeploymentManagerIT.testFailedDeployMulti,NOD,,,https://github.com/TestingResearchIllinois/idoft/issues/229
 https://github.com/wildfly/wildfly-maven-plugin,ba664f977f4a20771eb7aab979164b2fb639a240,core,org.wildfly.plugin.core.DomainDeploymentManagerIT.testFailedForceDeploy,NOD,,,https://github.com/TestingResearchIllinois/idoft/issues/229


### PR DESCRIPTION
This PR is for [issue-728](https://github.com/TestingResearchIllinois/idoft/issues/728)

Two flaky tests were fixed in wildfly-core in the cli module. 

- Here is the JIRA issue created [WFCORE-6214](https://issues.redhat.com/browse/WFCORE-6214)
- Here is the [PR to wildfly-core repo](https://github.com/wildfly/wildfly-core/pull/5366) that was opened to fix both flaky tests. The steps to reproduce and fix the flaky tests are described in this PR.

Following changes were made to pr-data.csv in this PR
- First flaky test `org.jboss.as.cli.impl.aesh.HelpSupportTestCase.testStandalone` was already in pr-data.csv, which was fixed in the above PR to wildfly-core. So I updated the line for this flaky test to include the right commit, set the status to opened and included the link to the wildfly-core repo
- Second flaky test `org.jboss.as.cli.impl.BootScriptInvoker.test` was also fixed in the above PR to wildfly-core, but it was not listed in pr-data.csv. So I added a new line for the flaky test with the appropriate details and ensured the file is the correct sorted order
