### PR TITLE
Updated pr-data.csv with accepted status of wildfly-core cli PR

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -5198,8 +5198,8 @@ https://github.com/wildfly/wildfly,cb7af61bfbb5615b522cabf8ded9a135178089b7,unde
 https://github.com/wildfly/wildfly,cb7af61bfbb5615b522cabf8ded9a135178089b7,undertow,org.wildfly.extension.undertow.UndertowSubsystem80TestCase.testRuntime,ID,Accepted,https://github.com/wildfly/wildfly/pull/13728,
 https://github.com/wildfly/wildfly,cb7af61bfbb5615b522cabf8ded9a135178089b7,undertow,org.wildfly.extension.undertow.UndertowSubsystem90TestCase.testRuntime,ID,Accepted,https://github.com/wildfly/wildfly/pull/13728,
 https://github.com/wildfly/wildfly,b19048b72669fc0e96665b1b125dc1fda21f5993,undertow,org.wildfly.extension.undertow.UndertowSubsystemTestCase.testRuntime,ID,,,
-https://github.com/wildfly/wildfly-core,624b3aa22e4064b42bd171e8d7753238a1d6616c,cli,org.jboss.as.cli.impl.aesh.HelpSupportTestCase.testStandalone,ID,Opened,https://github.com/wildfly/wildfly-core/pull/5366,
-https://github.com/wildfly/wildfly-core,db72abab9b89203891f5c84e0526028dc5f4e9ef,cli,org.jboss.as.cli.impl.BootScriptInvoker.test,ID,Opened,https://github.com/wildfly/wildfly-core/pull/5366,
+https://github.com/wildfly/wildfly-core,624b3aa22e4064b42bd171e8d7753238a1d6616c,cli,org.jboss.as.cli.impl.aesh.HelpSupportTestCase.testStandalone,ID,Accepted,https://github.com/wildfly/wildfly-core/pull/5366,
+https://github.com/wildfly/wildfly-core,db72abab9b89203891f5c84e0526028dc5f4e9ef,cli,org.jboss.as.cli.impl.BootScriptInvoker.test,ID,Accepted,https://github.com/wildfly/wildfly-core/pull/5366,
 https://github.com/wildfly/wildfly-maven-plugin,ba664f977f4a20771eb7aab979164b2fb639a240,core,org.wildfly.plugin.core.DomainDeploymentManagerIT.testDeploy,NOD,,,https://github.com/TestingResearchIllinois/idoft/issues/229
 https://github.com/wildfly/wildfly-maven-plugin,ba664f977f4a20771eb7aab979164b2fb639a240,core,org.wildfly.plugin.core.DomainDeploymentManagerIT.testFailedDeployMulti,NOD,,,https://github.com/TestingResearchIllinois/idoft/issues/229
 https://github.com/wildfly/wildfly-maven-plugin,ba664f977f4a20771eb7aab979164b2fb639a240,core,org.wildfly.plugin.core.DomainDeploymentManagerIT.testFailedForceDeploy,NOD,,,https://github.com/TestingResearchIllinois/idoft/issues/229


### PR DESCRIPTION
This PR is for [issue-728](https://github.com/TestingResearchIllinois/idoft/issues/728)

Two flaky tests were fixed in wildfly-core in the cli module.  These changes are now accepted and merged into the repository.

**This PR is to update `pr-data.csv` with the accepted status of my two changes.**

- Here is the JIRA issue created [WFCORE-6214](https://issues.redhat.com/browse/WFCORE-6214)
- Here is the [PR to wildfly-core repo](https://github.com/wildfly/wildfly-core/pull/5366) that was opened and accepted to fix both flaky tests. The steps to reproduce and fix the flaky tests are described in this PR.

Following changes were made to pr-data.csv in this PR
- Updated the status of these the following tests from opened to accepted: `org.jboss.as.cli.impl.aesh.HelpSupportTestCase.testStandalone` and  `org.jboss.as.cli.impl.BootScriptInvoker.test`








