### PR TITLE
 Adding notes to CompatParquetReaderTest.testParquetThriftCompat

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -1145,7 +1145,7 @@ https://github.com/apache/dolphinscheduler,26b7541d954ba63deb37e89479ab4d648573e
 https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/avro-extensions,org.apache.druid.data.input.AvroStreamInputFormatTest.testParseSchemaless,ID,,,
 https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/avro-extensions,org.apache.druid.data.input.AvroStreamInputRowParserTest.testParseSchemaless,ID,,,
 https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/parquet-extensions,org.apache.druid.data.input.parquet.CompatParquetReaderTest.testBinaryAsString,ID,,,
-https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/parquet-extensions,org.apache.druid.data.input.parquet.CompatParquetReaderTest.testParquetThriftCompat,ID,,,
+https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/parquet-extensions,org.apache.druid.data.input.parquet.CompatParquetReaderTest.testParquetThriftCompat,ID,,,https://github.com/TestingResearchIllinois/idoft/issues/734
 https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/parquet-extensions,org.apache.druid.data.input.parquet.CompatParquetReaderTest.testProtoStructWithArray,ID,,,
 https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/parquet-extensions,org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest.testFlat1Autodiscover,ID,,,
 https://github.com/apache/druid,50963edcae70150f13520b619f167512d951a71b,extensions-core/parquet-extensions,org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest.testFlat1Flatten,ID,,,


### PR DESCRIPTION
This PR is for [issue-734](https://github.com/TestingResearchIllinois/idoft/issues/734)

**GitHub repo: https://github.com/apache/druid
Commit: 50963edcae70150f13520b619f167512d951a71b
Module Path: extensions-core/parquet-extensions
Fully-Qualified Test Name: org.apache.druid.data.input.parquet.CompatParquetReaderTest.testParquetThriftCompat
Category: ID (Implementation-Dependent Tests found by Nondex)**

Fix is proposed is for apache druid in extensions-core/parquet-extensions module.

Here is the [draft PR](https://github.com/BalaNaren/druid/pull/1) in my forked repo.

Changes are made to pr-data.csv, added a note the already existing line.

Contributed By:
**Bala Naren Chanumolu
College Email: [bchanumo@gmu.edu](mailto:bchanumo@gmu.edu)
Personal Email: [4568naren@gmail.com](mailto:4568naren@gmail.com)**