### PR TITLE
Fixed flaky test in 'apache/pinot' repository.

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -2647,7 +2647,7 @@ https://github.com/apache/pinot,2253bd717a10c15220a1157316e233d11531e04b,pinot-c
 https://github.com/apache/pinot,85e413ebe8c80513a8a676fc090b1af0f50861f0,pinot-common,org.apache.pinot.common.utils.URIUtilsTest.testBuildURI,ID,Accepted,https://github.com/apache/pinot/pull/9928,
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.core.operator.filter.NotFilterOperatorTest.testNotOperator,ID,,,
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManagerTest.testQuerySubmitAndCompletionStats,ID,,,
-https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.core.util.CrcUtilsTest.test1,ID,,,
+https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.core.util.CrcUtilsTest.test1,ID,InspiredAFix,https://github.com/apache/pinot/pull/10445,https://github.com/apache/pinot/issues/10442
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.BigDecimalQueriesTest.testQueriesWithDictColumn,ID,,,
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.BigDecimalQueriesTest.testQueriesWithNoDictColumn,ID,,,
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.BooleanNullEnabledQueriesTest.testQueriesWithDictColumn,ID,,,


### PR DESCRIPTION
Contributing fix for 'CrcUtilsTest' flaky test(#10442), PR is created. This issue is confirmed by one of the PMCs of this project. Link to the PR: apache/pinot#10445.

The following changes were made to pr-data.csv in this PR:

Flaky test org.apache.pinot.core.util.CrcUtilsTest.test1 was already in pr-data.csv, I updated the line for this flaky test to include the fix PR link and set the status to opened.