### PR TITLE
Add new flaky test in checkstyle repo

### DIFF
--- a/format_checker/forked-projects.json
+++ b/format_checker/forked-projects.json
@@ -167,6 +167,7 @@
   "https://github.com/castle/castle-java": "unforked",
   "https://github.com/cerner/common-kafka": "unforked",
   "https://github.com/cescoffier/vertx-completable-future": "unforked",
+  "https://github.com/checkstyle/checkstyle": "unforked",
   "https://github.com/classgraph/classgraph": "unforked",
   "https://github.com/cloudera/altus-sdk-java": "unforked",
   "https://github.com/code4craft/tiny-spring": "unforked",

--- a/pr-data.csv
+++ b/pr-data.csv
@@ -2947,6 +2947,7 @@ https://github.com/cerner/common-kafka,d7873514c1705575c642ed99d2fa501f9b319790,
 https://github.com/cerner/common-kafka,d7873514c1705575c642ed99d2fa501f9b319790,common-kafka,com.cerner.common.kafka.consumer.ProcessingPartitionTest.nextRecord_manyRecords,ID,,,
 https://github.com/cerner/common-kafka,d7873514c1705575c642ed99d2fa501f9b319790,common-kafka,com.cerner.common.kafka.consumer.ProcessingPartitionTest.nextRecord_skipPendingAndCompletedRecords,ID,,,
 https://github.com/cescoffier/vertx-completable-future,011d3cd963b9a810c2e8e616da27bbfd8a3c717e,.,me.escoffier.vertx.completablefuture.VertxCompletableFutureTest.testAcceptEitherAsyncWithExecutor,NOD,,,
+https://github.com/checkstyle/checkstyle,c3a4af8c608684cea98c727051b188de1813fc83,.,com.puppycrawl.tools.checkstyle.JavadocPropertiesGeneratorTest.testNonExistentArgument,ID,,,
 https://github.com/classgraph/classgraph,d3b5aebd2d9bfc8b98539f7ce157775cc5af6e95,.,io.github.classgraph.json.JSONSerializationTest.testJSON,ID,Accepted,https://github.com/classgraph/classgraph/pull/383,
 https://github.com/cloudera/altus-sdk-java,914688f557923a8d9fae44b4da318e3e66c96d74,.,com.cloudera.altus.client.AltusClientTest.testBadAltusErrors,ID,RepoArchived,,
 https://github.com/CloudSlang/cloud-slang,48923570780dd096e0cf17ef657b6b1fdc50dc31,cloudslang-entities,io.cloudslang.fortest.SensitiveValueTest.testEncryptedStringSensitiveValue,OD,,,https://github.com/TestingResearchIllinois/flaky-test-dataset/issues/79


### PR DESCRIPTION
There is 1 ID flaky test in checkstyle repo

Steps to reproduce:
Run the following command in the base of the repository -

```mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex```

The repository can be found at:  https://github.com/checkstyle/checkstyle
