### PR TITLE
New Flaky Tests for druid

### DIFF
--- a/format_checker/forked-projects.json
+++ b/format_checker/forked-projects.json
@@ -361,5 +361,6 @@
   "https://github.com/yandex/yoctodb": "unforked",
   "https://github.com/yangfuhai/jboot": "unforked",
   "https://github.com/zalando/riptide": "unforked",
-  "https://github.com/zhangxd1989/spring-boot-cloud": "unforked"
+  "https://github.com/zhangxd1989/spring-boot-cloud": "unforked",
+  "https://github.com/zzjas/druid": "forked"
 }

--- a/format_checker/forked-projects.json
+++ b/format_checker/forked-projects.json
@@ -362,5 +362,5 @@
   "https://github.com/yangfuhai/jboot": "unforked",
   "https://github.com/zalando/riptide": "unforked",
   "https://github.com/zhangxd1989/spring-boot-cloud": "unforked",
-  "https://github.com/zzjas/druid": "forked"
+  "https://github.com/zzjas/druid": "unforked"
 }

--- a/pr-data.csv
+++ b/pr-data.csv
@@ -5493,5 +5493,5 @@ https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,ript
 https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,riptide-spring-boot-starter,org.zalando.riptide.spring.ObjectMapperOverrideTest.shouldOverride,ID,MovedOrRenamed,,https://github.com/zalando/riptide/commit/cef45a1e325b5b1fdc4c47def3269ad3578b1fe1
 https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,riptide-spring-boot-starter,org.zalando.riptide.spring.url.UrlResolutionTest.shouldAppendUrl,UD,,,
 https://github.com/zhangxd1989/spring-boot-cloud,e3966d7cefa4fa429d13bbc8de7f4dafbae0de35,registry,cn.zhangxd.registry.ApplicationTests.catalogLoads,ID,,,
-https://github.com/zzjas/druid,ad32f8458670339808a3136a9578a10a52b8394f,processing,org.apache.druid.segment.virtual.ExpressionVirtualColumnTest.testRequiredColumns,ID,,,	
+https://github.com/zzjas/druid,ad32f8458670339808a3136a9578a10a52b8394f,processing,org.apache.druid.segment.virtual.ExpressionVirtualColumnTest.testRequiredColumns,ID,,,
 https://github.com/zzjas/druid,ad32f8458670339808a3136a9578a10a52b8394f,processing,org.apache.druid.segment.virtual.VirtualColumnsTest.testCompositeVirtualColumnsCyclesTree,ID,,,

--- a/pr-data.csv
+++ b/pr-data.csv
@@ -5493,3 +5493,5 @@ https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,ript
 https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,riptide-spring-boot-starter,org.zalando.riptide.spring.ObjectMapperOverrideTest.shouldOverride,ID,MovedOrRenamed,,https://github.com/zalando/riptide/commit/cef45a1e325b5b1fdc4c47def3269ad3578b1fe1
 https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,riptide-spring-boot-starter,org.zalando.riptide.spring.url.UrlResolutionTest.shouldAppendUrl,UD,,,
 https://github.com/zhangxd1989/spring-boot-cloud,e3966d7cefa4fa429d13bbc8de7f4dafbae0de35,registry,cn.zhangxd.registry.ApplicationTests.catalogLoads,ID,,,
+https://github.com/zzjas/druid,ad32f8458670339808a3136a9578a10a52b8394f,processing,org.apache.druid.segment.virtual.ExpressionVirtualColumnTest.testRequiredColumns,ID,,,	
+https://github.com/zzjas/druid,ad32f8458670339808a3136a9578a10a52b8394f,processing,org.apache.druid.segment.virtual.VirtualColumnsTest.testCompositeVirtualColumnsCyclesTree,ID,,,


### PR DESCRIPTION
Repo: https://github.com/zzjas/druid
Module : processing
Tests:
1. org.apache.druid.segment.virtual.ExpressionVirtualColumnTest.testRequiredColumns
2. org.apache.druid.segment.virtual.VirtualColumnsTest.testCompositeVirtualColumnsCyclesTree

Commands run:
mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex |& tee nondex-$(date +%s).log

mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.segment.virtual.ExpressionVirtualColumnTest#testRequiredColumns |& tee nondex-$(date +%s).log

`[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.057 s <<< FAILURE! -- in org.apache.druid.segment.virtual.ExpressionVirtualColumnTest
[ERROR] org.apache.druid.segment.virtual.ExpressionVirtualColumnTest.testRequiredColumns -- Time elapsed: 0.008 s <<< FAILURE!
java.lang.AssertionError: expected:<[x, z]> but was:<[z, x]>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.druid.segment.virtual.ExpressionVirtualColumnTest.testRequiredColumns(ExpressionVirtualColumnTest.java:739)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)`


mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.segment.virtual.VirtualColumnsTest#testCompositeVirtualColumnsCyclesTree |& tee nondex-$(date +%s).log

`[INFO] Running org.apache.druid.segment.virtual.VirtualColumnsTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.234 s <<< FAILURE! -- in org.apache.druid.segment.virtual.VirtualColumnsTest
[ERROR] org.apache.druid.segment.virtual.VirtualColumnsTest.testCompositeVirtualColumnsCyclesTree -- Time elapsed: 2.219 s <<< ERROR!
org.apache.druid.java.util.common.IAE: Self-referential column[v1]
	at org.apache.druid.segment.VirtualColumns.detectCycles(VirtualColumns.java:472)
	at org.apache.druid.segment.VirtualColumns.detectCycles(VirtualColumns.java:474)
	at org.apache.druid.segment.VirtualColumns.<init>(VirtualColumns.java:140)
	at org.apache.druid.segment.VirtualColumns.create(VirtualColumns.java:112)
	at org.apache.druid.segment.virtual.VirtualColumnsTest.testCompositeVirtualColumnsCyclesTree(VirtualColumnsTest.java:467)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)`