### PR TITLE
Delete Non Flaky ta4j repo tests

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -4920,10 +4920,6 @@ https://github.com/stleary/JSON-java,8353b9c3f06239c2ffe5b8a39e67ffc72893f666,.,
 https://github.com/stleary/JSON-java,8353b9c3f06239c2ffe5b8a39e67ffc72893f666,.,org.json.junit.XMLTest.testIndentSimpleJsonArray,ID,Accepted,https://github.com/stleary/JSON-java/pull/734,
 https://github.com/stleary/JSON-java,8353b9c3f06239c2ffe5b8a39e67ffc72893f666,.,org.json.junit.XMLTest.testIndentSimpleJsonObject,ID,Accepted,https://github.com/stleary/JSON-java/pull/734,
 https://github.com/streamx-co/FluentJPA,4faabd6739e53db9b98630e3e348d367c92e705f,.,co.streamx.fluent.JPA.FamilyTest.test1,ID,Accepted,https://github.com/streamx-co/FluentJPA/pull/4,
-https://github.com/ta4j/ta4j,09cb8397161052403438c22c46404e2bc0c454ab,ta4j-examples,ta4jexamples.analysis.BuyAndSellSignalsToChartTest.test,ID,,,
-https://github.com/ta4j/ta4j,09cb8397161052403438c22c46404e2bc0c454ab,ta4j-examples,ta4jexamples.analysis.CashFlowToChartTest.test,ID,,,
-https://github.com/ta4j/ta4j,09cb8397161052403438c22c46404e2bc0c454ab,ta4j-examples,ta4jexamples.indicators.CandlestickChartTest.test,ID,,,
-https://github.com/ta4j/ta4j,09cb8397161052403438c22c46404e2bc0c454ab,ta4j-examples,ta4jexamples.indicators.IndicatorsToChartTest.test,ID,,,
 https://github.com/tabulapdf/tabula-java,b0fde49e6aa06593d16c8aa0b8da0e3172db1ec2,.,technology.tabula.TestSpreadsheetExtractor.testRTL,ID,,,
 https://github.com/takari/ollie,60c0ec5007779863a82c01eeba1a81f6864bb083,ollie,com.walmartlabs.ollie.app.OllieSslServerTest.validate,NOD,,,https://github.com/TestingResearchIllinois/idoft/issues/148
 https://github.com/takari/ollie,60c0ec5007779863a82c01eeba1a81f6864bb083,ollie,com.walmartlabs.ollie.config.ConfigurationProcessorTest.validateConfigurationProcessor,OD,,,https://github.com/TestingResearchIllinois/idoft/issues/148


### PR DESCRIPTION
These tests are not flaky, build succeeds with NonDex tool even with iterations=100.
`mvn -pl ta4j-examples test -Dtest=ta4jexamples.analysis.BuyAndSellSignalsToChartTest#test` results in the following error when run in a remote vm:
```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.828 sec <<< FAILURE!
test(ta4jexamples.analysis.BuyAndSellSignalsToChartTest)  Time elapsed: 1.773 sec  <<< ERROR!
java.awt.HeadlessException: 
No X11 DISPLAY variable was set, but this program performed an operation which requires it.
```
When I run the command `mvn -pl ta4j-examples test -Dtest=ta4jexamples.analysis.BuyAndSellSignalsToChartTest#test` (also with Nondex) on a **linux machine with UI**, the build succeeds.
Similarly the following tests pass with 100 iterations of NonDex:  `ta4jexamples.indicators.IndicatorsToChartTest.test`, `ta4jexamples.indicators.CandlestickChartTest.test`, `ta4jexamples.analysis.CashFlowToChartTest.test`