### PR TITLE
Add detected flaky test

### DIFF
--- a/format_checker/forked-projects.json
+++ b/format_checker/forked-projects.json
@@ -300,6 +300,7 @@
   "https://github.com/orbisgis/h2gis": "unforked",
   "https://github.com/orbit/orbit": "unforked",
   "https://github.com/outbrain/aletheia": "unforked",
+  "https://github.com/pac4j/pac4j": "unforked",
   "https://github.com/paleozogt/symzip-plugin": "unforked",
   "https://github.com/paypal/sdk-core-java": "unforked",
   "https://github.com/pazzesko/pokemon-alea": "unforked",

--- a/pr-data.csv
+++ b/pr-data.csv
@@ -4291,6 +4291,7 @@ https://github.com/outbrain/aletheia,024a4b7ea4c186329bbe1e20bb31048d95add836,al
 https://github.com/outbrain/aletheia,024a4b7ea4c186329bbe1e20bb31048d95add836,aletheia-core,com.outbrain.aletheia.SampleDomainClassDatumTest.test_avro_route,NOD,RepoDeleted,,
 https://github.com/outbrain/aletheia,024a4b7ea4c186329bbe1e20bb31048d95add836,aletheia-core,com.outbrain.aletheia.SampleDomainClassDatumTest.test_json_route,NOD,RepoDeleted,,
 https://github.com/outbrain/aletheia,024a4b7ea4c186329bbe1e20bb31048d95add836,aletheia-core,com.outbrain.aletheia.SampleDomainClassDatumTest.test_multiple_routes,NOD,RepoDeleted,,
+https://github.com/pac4j/pac4j,d004d027a2dff5b42e2f5424eff6aa557f0fe6a9,pac4j-oauth,org.pac4j.oauth.profile.JsonHelperTests.testToJSONString,ID,,,
 https://github.com/paypal/sdk-core-java,42e793eeafae2fd1cb90fe2cc81a8ba22be830da,.,com.paypal.core.rest.RESTUtilTest.testFormatURIPathMapQueryMap,ID,RepoArchived,,
 https://github.com/paypal/sdk-core-java,42e793eeafae2fd1cb90fe2cc81a8ba22be830da,.,com.paypal.core.rest.RESTUtilTest.testFormatURIPathMapQueryMapQueryURIPath,ID,RepoArchived,,
 https://github.com/pedrovgs/Algorithms,ed6f8a49948c09a21bfeb7bc38b4f24141795e38,.,com.github.pedrovgs.problem45.FindNthMostRepeatedElementTest.shouldFindNthMostRepeatedElement,ID,Accepted,https://github.com/pedrovgs/Algorithms/pull/63,


### PR DESCRIPTION
There is 1 ID flaky test in [pac4j](https://github.com/pac4j/pac4j) repo

Steps to reproduce:
Run the following command in the base of the repository -

```mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex```

Test fails on `nondexSeed=974622`

I verify it with the command:
`mvn -pl pac4j-oauth edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.pac4j.oauth.profile.JsonHelperTests#testToJSONString -DnondexRuns=10`

Please find log files here: `~/pac4j/pac4jnondexlog.log`
VM name: ` fa23-cs527-054.cs.illinois.edu`