### PR TITLE
Remove hadoop test which is not flaky

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -1667,7 +1667,6 @@ https://github.com/apache/hadoop,cc2babc1f75c93bf89a8f10da525f944c15d02ea,hadoop
 https://github.com/apache/hadoop,cc2babc1f75c93bf89a8f10da525f944c15d02ea,hadoop-common-project/hadoop-auth,org.apache.hadoop.security.authentication.util.TestKerberosName.testRules,OD-Vic,,,
 https://github.com/apache/hadoop,14cd969b6ea1898e9db6eeb9ea5292ec4558a706,hadoop-common-project/hadoop-common,org.apache.hadoop.security.TestGroupsCaching.testNegativeGroupCaching,ID,Accepted,https://github.com/apache/hadoop/pull/1835,
 https://github.com/apache/hadoop,cc2babc1f75c93bf89a8f10da525f944c15d02ea,hadoop-hdfs-project/hadoop-hdfs-httpfs,org.apache.hadoop.test.TestHFSTestCase.testHadoopFileSystem,OD,,,
-https://github.com/apache/hadoop,cc2babc1f75c93bf89a8f10da525f944c15d02ea,hadoop-hdfs-project/hadoop-hdfs-httpfs,org.apache.hadoop.test.TestHFSTestCase.waitFor,ID,,,
 https://github.com/apache/hadoop,cc2babc1f75c93bf89a8f10da525f944c15d02ea,hadoop-hdfs-project/hadoop-hdfs-httpfs,org.apache.hadoop.test.TestHFSTestCase.waitForTimeOutRatio1,ID,,,
 https://github.com/apache/hadoop,cc2babc1f75c93bf89a8f10da525f944c15d02ea,hadoop-hdfs-project/hadoop-hdfs-httpfs,org.apache.hadoop.test.TestHTestCase.waitForTimeOutRatio1,ID,,,
 https://github.com/apache/hadoop,cc2babc1f75c93bf89a8f10da525f944c15d02ea,hadoop-hdfs-project/hadoop-hdfs-httpfs,org.apache.hadoop.test.TestHTestCase.waitForTimeOutRatio2,ID,,,


### PR DESCRIPTION
This test is not flaky in the latest code as well as in the detected commit.

I ran the following tests and ALL of them  PASSED.

**Latest code:**
1. Regular test
2. Regular test for full class
3. Regular test for full module
4. NonDex test
5. NonDex test for full class
6. NonDex test for full module

**Detected commit SHA:**
1. Regular test
2. Regular test for full class
3. Regular test for full module
4. NonDex test
5. NonDex test for full class
6. NonDex test for full module

All the tests PASSED. Therefore deleting the test.

Logs are in my VM: /home/bbelide2/project/hadoop/logs/test2/java8
