### PR TITLE
update /FudanNLP/fnlp

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -3374,8 +3374,7 @@ https://github.com/fromage/redpipe,0aff891d6befdf0dcc2bdbfda22262cdf82ac66f,redp
 https://github.com/fromage/redpipe,0aff891d6befdf0dcc2bdbfda22262cdf82ac66f,redpipe-templating-freemarker,net.redpipe.templating.freemarker.ApiTest.checkTemplateNegociationDefault,ID,Opened,https://github.com/fromage/redpipe/pull/56,
 https://github.com/fromage/redpipe,0aff891d6befdf0dcc2bdbfda22262cdf82ac66f,redpipe-templating-freemarker,net.redpipe.templating.freemarker.ApiTest.checkTemplateNegociationSingleHtml,NOD,RepoArchived,,
 https://github.com/fromage/redpipe,0aff891d6befdf0dcc2bdbfda22262cdf82ac66f,redpipe-templating-freemarker,net.redpipe.templating.freemarker.ApiTest.checkTemplateNegociationText,NOD,RepoArchived,,
-https://github.com/FudanNLP/fnlp,ce258f3e4a5add2ba0b5e4cbac7cab2190af6659,fnlp-core,org.fnlp.nlp.cn.tag.CWSTaggerTest.org.fnlp.nlp.cn.tag.CWSTaggerTest,ID,,,
-https://github.com/FudanNLP/fnlp,ce258f3e4a5add2ba0b5e4cbac7cab2190af6659,fnlp-core,org.fnlp.nlp.cn.tag.POSTaggerTest.org.fnlp.nlp.cn.tag.POSTaggerTest,ID,,,
+https://github.com/FudanNLP/fnlp,ce258f3e4a5add2ba0b5e4cbac7cab2190af6659,fnlp-core,org.fnlp.nlp.cn.tag.CWSTaggerTest,ID,Opened,https://github.com/FudanNLP/fnlp/pull/70,
 https://github.com/funkygao/cp-ddd-framework,8c69f6a50db83459356a2ae66a910b1905fe4eb5,dddplus-test,io.github.dddplus.runtime.registry.IntegrationTest.exportDomainArtifacts,ID,Accepted,https://github.com/funkygao/cp-ddd-framework/pull/65,
 https://github.com/funkygao/cp-ddd-framework,8c69f6a50db83459356a2ae66a910b1905fe4eb5,dddplus-test,io.github.dddplus.testing.LogAssertTest.contains,OD,,,https://github.com/TestingResearchIllinois/flaky-test-dataset/issues/80
 https://github.com/gchq/Gaffer,ca465ec9243c7ed981528379e351bddeae8d5c83,core/common-util,uk.gov.gchq.gaffer.commonutil.OneOrMoreTest.shouldAddAllItemsWithDeduplicate,ID,Accepted,https://github.com/gchq/Gaffer/pull/3033,


### PR DESCRIPTION
There are two tests in one GitHub repo.

First test: 
`https://github.com/FudanNLP/fnlp,ce258f3e4a5add2ba0b5e4cbac7cab2190af6659,fnlp-core,org.fnlp.nlp.cn.tag.CWSTaggerTest.org.fnlp.nlp.cn.tag.CWSTaggerTest,ID,,,`

First, the location of the test is wrong on the pr-data, it is `org.fnlp.nlp.cn.tag.CWSTaggerTest` not `org.fnlp.nlp.cn.tag.CWSTaggerTest.org.fnlp.nlp.cn.tag.CWSTaggerTest`. 
Pr link to the fix: https://github.com/FudanNLP/fnlp/pull/70

Second test:

`https://github.com/FudanNLP/fnlp,ce258f3e4a5add2ba0b5e4cbac7cab2190af6659,fnlp-core,org.fnlp.nlp.cn.tag.POSTaggerTest.org.fnlp.nlp.cn.tag.POSTaggerTest,ID,,,`


As the first test, the location of the test class is wrong. 
But after all the test, the POSTaggerTest.java is not failing at all. The `mvn test` shows the fnlp-demo fails, not fnlp-core that the POSTaggerTest was in. So I think remove this test.
The error message:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for fnlp-all 2.1-SNAPSHOT:
[INFO] 
[INFO] fnlp-core .......................................... SUCCESS [  5.516 s]
[INFO] fnlp-all ........................................... SUCCESS [  0.003 s]
[INFO] fnlp-dev ........................................... SUCCESS [  0.880 s]
[INFO] fnlp-train ......................................... SUCCESS [  0.975 s]
[INFO] fnlp-app ........................................... SUCCESS [  2.701 s]
[INFO] fnlp-demo .......................................... FAILURE [ 15.912 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  26.122 s
[INFO] Finished at: 2023-10-26T21:10:49-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project fnlp-demo: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test failed: The forked VM terminated without saying properly goodbye. VM crash or System.exit called ? -> [Help 1]
```
