### PR TITLE
Update status of deleted tests in gr-data.csv

### DIFF
--- a/gr-data.csv
+++ b/gr-data.csv
@@ -474,10 +474,10 @@ https://github.com/sogis/gretl,9f547d3440f73c3d58a949c11f1c59cde9e68758,gretl,ch
 https://github.com/sogis/gretl,9f547d3440f73c3d58a949c11f1c59cde9e68758,gretl,ch.so.agi.gretl.steps.PublisherStepFile2LocalTest.file_regionsRegEx,ID-HtF,,,
 https://github.com/sogis/gretl,9f547d3440f73c3d58a949c11f1c59cde9e68758,gretl,ch.so.agi.gretl.steps.PublisherStepFile2LocalTest.file_regionsUpdate,ID-HtF,,,
 https://github.com/square/retrofit,14b9b8c88ff80789a48dfdfad2c91463cc4333ad,retrofit,retrofit2.CompletableFutureAndroidTest.completableFutureApi24,ID,,,
-https://github.com/square/retrofit,14b9b8c88ff80789a48dfdfad2c91463cc4333ad,retrofit,retrofit2.CompletableFutureAndroidTest.completableFuturePreApi24,ID,,,
+https://github.com/square/retrofit,14b9b8c88ff80789a48dfdfad2c91463cc4333ad,retrofit,retrofit2.CompletableFutureAndroidTest.completableFuturePreApi24,ID,Deleted,,https://github.com/square/retrofit/commit/34f6a7fdc2f359d05a32f3262825563fc10929b4
 https://github.com/square/retrofit,14b9b8c88ff80789a48dfdfad2c91463cc4333ad,retrofit,retrofit2.OptionalConverterFactoryAndroidTest.onlyMatchesOptional,ID,,,
 https://github.com/square/retrofit,14b9b8c88ff80789a48dfdfad2c91463cc4333ad,retrofit,retrofit2.OptionalConverterFactoryAndroidTest.optionalApi24,ID,,,
-https://github.com/square/retrofit,14b9b8c88ff80789a48dfdfad2c91463cc4333ad,retrofit,retrofit2.OptionalConverterFactoryAndroidTest.optionalPreApi24,ID,,,
+https://github.com/square/retrofit,14b9b8c88ff80789a48dfdfad2c91463cc4333ad,retrofit,retrofit2.OptionalConverterFactoryAndroidTest.optionalPreApi24,ID,Deleted,,https://github.com/square/retrofit/commit/34f6a7fdc2f359d05a32f3262825563fc10929b4
 https://github.com/tehlers/gradle-duplicate-classes-check,4754962bc8df030289c77f347f10790d600a27a8,.,net.idlestate.gradle.duplicates.CheckDuplicateClassesEngineTest.testExcludeJarFiles,ID,,,
 https://github.com/tehlers/gradle-duplicate-classes-check,4754962bc8df030289c77f347f10790d600a27a8,.,net.idlestate.gradle.duplicates.CheckDuplicateClassesEngineTest.testSearchForDuplicates,ID,,,
 https://github.com/themoment-team/K2-server,c93e1ad31d4619f4b972e9d8d6fdc15c99fa2c55,.,com.moment.the.controller.release.UncomfortableControllerTest.top30_검증,ID,,,


### PR DESCRIPTION
**Repo:** https://github.com/square/retrofit

The following 2 tests were deleted when the project introduced android module:
1. retrofit2.CompletableFutureAndroidTest.completableFuturePreApi24
2. retrofit2.OptionalConverterFactoryAndroidTest.optionalPreApi24

**Deletion details**
**Commit** : https://github.com/square/retrofit/commit/34f6a7fdc2f359d05a32f3262825563fc10929b4
**PR** : https://github.com/square/retrofit/pull/3367

This PR marks these tests as deleted.