### PR TITLE
Added script for checking stale entries and sorting forked-projects.json

### DIFF
--- a/format_checker/forked_projects_util.py
+++ b/format_checker/forked_projects_util.py
@@ -1,0 +1,104 @@
+import json
+import os
+import csv
+import sys
+import errorhandler
+import logging
+from utils import (
+    log_info,
+    log_esp_error,
+    log_std_error,
+    log_warning
+)
+
+
+def combine_csvs(*input_csv_paths):
+    combined_data = []
+
+    for input_csv_path in input_csv_paths:
+        with open(input_csv_path, "r") as input_file:
+            reader = csv.reader(input_file)
+            header = next(reader)
+            combined_data.extend([row for row in reader])
+    return combined_data
+
+
+def check_csv(forked_data, *csv_file_path):
+    project_urls_set = set()
+    combined_data = combine_csvs(*csv_file_path)
+
+    for row in combined_data:
+        project_url = row[0]
+        project_urls_set.add(project_url)
+
+    # Read the forked JSON file
+    with open("format_checker/forked-projects.json", "r") as json_file:
+        forked_data = json.load(json_file)
+
+    # Check if each entry in forked_projects is present in the set of project URLs
+    anamalous_urls = []
+    for forked_entry in forked_data:
+        project_url = forked_entry
+        if project_url not in project_urls_set:
+            anamalous_urls.append(project_url)
+    return anamalous_urls
+
+
+def is_fp_sorted(data):
+    sorted_data = dict(sorted(data.items()))
+    list1 = list(data.items())
+    list2 = list(sorted_data.items())
+    return list1 == list2
+
+def update_fp(data, file_path):
+    sorted_data = dict(sorted(data.items()))
+
+    with open(file_path, "w") as file:
+        json.dump(sorted_data, file, indent=2)
+        
+def check_stale_fp(data, file_path, log):
+    urls = check_csv(data, "pr-data.csv", "gr-data.csv", "py-data.csv")
+    if len(urls) > 0:
+        log_esp_error(file_path, log, "Missing urls in csv:")
+        for url in urls:
+            log_esp_error(file_path, log, url)
+    else:
+        log_info(file_path, log, "There are no changes to be checked")
+        
+    update_fp(data, file_path)
+
+
+def run_checks_sort_fp(file_path, log):
+    with open(file_path, "r") as file:
+        data = json.load(file)
+    if not is_fp_sorted(data):
+        log_esp_error(file_path, log, "Entries are not sorted")
+    else:
+        log_info(file_path, log, "There are no changes to be checked")
+
+
+def main():
+    error_handler = errorhandler.ErrorHandler()
+    stream_handler = logging.StreamHandler(stream=sys.stderr)
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logger.addHandler(stream_handler)
+    log_std_error.tracker = 0
+    log_esp_error.tracker = 0
+    log_warning.tracker = 0
+    args = sys.argv[1:]
+    file_path="format_checker/forked-projects.json"
+    with open(file_path, "r") as file:
+        data = json.load(file)
+    if "check-sort" in args:
+        print(is_fp_sorted(data))
+    elif "check-stale" in args:
+        check_stale_fp(data,file_path, logger)
+    elif "sort" in args:
+        update_fp(data,file_path)
+    else:
+         log_esp_error(file_path, logger, f"{args[0]} is invalid")
+
+
+if __name__ == "__main__":
+    main()

--- a/format_checker/main.py
+++ b/format_checker/main.py
@@ -5,6 +5,7 @@ import logging
 import errorhandler
 from tso_iso_checker import run_checks_tso_iso
 from tic_fic_checker import run_checks_tic_fic
+from forked_projects_util import run_checks_sort_fp
 from pr_checker import run_checks_pr
 from utils import log_std_error, log_esp_error, log_warning
 
@@ -21,6 +22,7 @@ if __name__ == "__main__":
     checks = [lambda *args: run_checks_pr('pr-data.csv', *args), lambda *args: run_checks_pr('gr-data.csv', *args), run_checks_tic_fic, run_checks_tso_iso]
     for check in checks:
         check(logger, sys.argv[1:])
+    run_checks_sort_fp('format_checker/forked-projects.json',logger)
     ERROR_COUNT = str(log_std_error.tracker + log_esp_error.tracker)
 
     if error_handler.fired:


### PR DESCRIPTION
The script works in unison with the rest of the scripts present in the idoft codebase. It is called when `format_checker/main.py` is executed. 
The script does the following on every run of `format_checker/main.py`:
- It runs a search on `pr-data.csv`, `gr-data.csv`, `py-data.csv` to check if there are any unused entries in forked-projects.json. If yes, it returns an error with the entries using the existing logging mechanisms in the codebase. If not, a success log is shown
- It sorts the data in alphabetical order 

This script can be extended to delete the stale entries in forked-projects.json rather than just showing the stale entries to be deleted. Do let me know if that needs to be done instead.

