### PR TITLE
Find one ID test in [linkis] repo

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -5805,3 +5805,4 @@ https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,ript
 https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,riptide-spring-boot-starter,org.zalando.riptide.spring.ObjectMapperOverrideTest.shouldOverride,ID,MovedOrRenamed,,https://github.com/zalando/riptide/commit/cef45a1e325b5b1fdc4c47def3269ad3578b1fe1
 https://github.com/zalando/riptide,8277e11fc069d8e24df0d233ef2577cc75659b75,riptide-spring-boot-starter,org.zalando.riptide.spring.url.UrlResolutionTest.shouldAppendUrl,UD,,,
 https://github.com/zhangxd1989/spring-boot-cloud,e3966d7cefa4fa429d13bbc8de7f4dafbae0de35,registry,cn.zhangxd.registry.ApplicationTests.catalogLoads,ID,Claimed,,
+https://github.com/apache/linkis, 2b47014684a0f8b2491fa5b90410e10537fcfaa6,linkis-commons,org.apache.linkis.common.exception.ExceptionManagerTest#testGenerateException,ID,,,


### PR DESCRIPTION
I found one ID flaky test in linkis repo under the links-commons module. The flaky test logs could be found in my VM `yijujt2@fa23-cs527-073.cs.illinois.edu`: `/home/yijujt2/linkis/linkis-id-detect.log`

The failure looks like:
```
[ERROR] Failures: 
[ERROR]   ExceptionManagerTest.testGenerateException:55 expected: <LinkisException{errCode=10000, desc='The map cannot be parsed normally, the map is empty or the LEVEL value is missing:(map不能被正常的解析，map为空或者缺少LEVEL值: ){desc=test, port=0, errCode=1, level=null, ip=null, serviceKind=null}', ip='null', port=0, serviceKind='null'}> but was: <LinkisException{errCode=10000, desc='The map cannot be parsed normally, the map is empty or the LEVEL value is missing:(map不能被正常的解析，map为空或者缺少LEVEL值: ){errCode=1, ip=null, desc=test, port=0, level=null, serviceKind=null}', ip='null', port=0, serviceKind='null'}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

I also fixed this ID, and I will open the other PR in linkis repo soon.