### PR TITLE
Add a new ID flaky test found in json-io repo

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -4610,6 +4610,7 @@ https://github.com/jchambers/pushy,da5f8b97106cd41278b421ec63e4e76a7313bed9,push
 https://github.com/jdbi/jdbi,17d4da9a7227a1604ce569e8180691282867c3c1,core,org.jdbi.v3.core.internal.IterableLikeTest.testSetToIterator,ID,DeveloperWontFix,https://github.com/jdbi/jdbi/pull/2551,
 https://github.com/jdbi/jdbi,17d4da9a7227a1604ce569e8180691282867c3c1,core,org.jdbi.v3.core.mapper.reflect.BeanMapperMockTest.shouldThrowOnPropertyTypeWithoutRegisteredMapper,ID,DeveloperWontFix,https://github.com/jdbi/jdbi/pull/2552,
 https://github.com/jdereg/java-util,245458a912e04bf85116b10f240e7b4be217cd4f,.,com.cedarsoftware.util.TestGraphComparator.testNewArrayElement,ID,,,
+https://github.com/jdereg/json-io,e2dfec0aa5b539f8b2e1eca8c56ebede4d9b1215,.,com.cedarsoftware.io.TestGraphComparatorList.testNewArrayElement,ID,,,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.AtomicBooleanTest.testAssignAtomicBoolean,ID,,,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.AtomicIntegerTest.testAssignAtomicInteger,ID,,,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.AtomicLongTest.testAssignAtomicLong,ID,,,


### PR DESCRIPTION
This flaky test is found by [nonDex](https://github.com/TestingResearchIllinois/NonDex), using `mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex`

The config is following:

```
nondexFilter=.*
nondexMode=FULL
nondexSeed=1016066
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false
nondexDir=/home/jakew4/json-io/.nondex
nondexJarDir=/home/jakew4/json-io/.nondex
nondexExecid=+3vliKQsIP8248mmy8WP2PECCNNv6thFVPebRPU2rQ=
nondexLogging=CONFIG
test=
```
The config file can be found here: [mp1-nondex-config-1.txt](https://github.com/user-attachments/files/16924296/mp1-nondex-config-1.txt)

<details>

<summary>Click on to see more details on the error message when running this flaky test</summary>

```
[WARNING]  Parameter 'disableXmlReport' (user property 'disableXmlReport') is deprecated: No reason given
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.cedarsoftware.io.TestGraphComparatorList
java-util using server id=97 for last two digits of generated unique IDs. Set using new SecureRandom()
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.842 s <<< FAILURE! -- in com.cedarsoftware.io.TestGraphComparatorList
[ERROR] com.cedarsoftware.io.TestGraphComparatorList.testNewArrayElement -- Time elapsed: 0.774 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:31)
        at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:183)
        at com.cedarsoftware.io.TestGraphComparatorList.testNewArrayElement(TestGraphComparatorList.java:674)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestGraphComparatorList.testNewArrayElement:674 expected: <true> but was: <false>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
```

</details>


The steps to reproduce the issue:

```
mvn install -pl . -am -DskipTests

mvn -pl . \
    test \
    -Dtest=com.cedarsoftware.io.TestGraphComparatorList#testNewArrayElement

mvn -pl . \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=com.cedarsoftware.io.TestGraphComparatorList#testNewArrayElement -DnondexRuns=10
```

The log output can be found here for your reference: [mp1-nondex-log-1.txt](https://github.com/user-attachments/files/16924280/mp1-nondex-log-1.txt)


