### PR TITLE
Add opened PR in json-io

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -4697,7 +4697,7 @@ https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.AtomicIntegerTest.testAssignAtomicInteger,ID,Accepted,https://github.com/jdereg/json-io/pull/295,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.AtomicLongTest.testAssignAtomicLong,ID,,,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.CollectionTests.testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded,ID,,,
-https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.EnumTests.testEnumWithPrivateMembersAsField_withPrivatesOn,ID,,,
+https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.EnumTests.testEnumWithPrivateMembersAsField_withPrivatesOn,ID,Opened,https://github.com/jdereg/json-io/pull/297,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.MapsTest.testMap,ID,,,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.MapsTest.testReconstituteMap,ID,,,
 https://github.com/jdereg/json-io,f8958ef52bbdc94f8aed7d98c96d2775200ec7e7,.,com.cedarsoftware.util.io.NoTypeTest.testNoType,ID,,,


### PR DESCRIPTION
I opened a pull request for a flaky test: com.cedarsoftware.util.io.EnumTests.testEnumWithPrivateMembersAsField_withPrivatesOn  (which is in json-io).

