### PR TITLE
Add `DeveloperFixed` status to a new ID test

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -4735,6 +4735,7 @@ https://github.com/jdbi/jdbi,17d4da9a7227a1604ce569e8180691282867c3c1,core,org.j
 https://github.com/jdbi/jdbi,17d4da9a7227a1604ce569e8180691282867c3c1,core,org.jdbi.v3.core.mapper.reflect.BeanMapperMockTest.shouldThrowOnPropertyTypeWithoutRegisteredMapper,ID,DeveloperWontFix,https://github.com/jdbi/jdbi/pull/2552,
 https://github.com/jdereg/java-util,245458a912e04bf85116b10f240e7b4be217cd4f,.,com.cedarsoftware.util.TestGraphComparator.testNewArrayElement,ID,Accepted,https://github.com/jdereg/java-util/pull/106,
 https://github.com/jdereg/json-io,45699f116bdaac9449cc58fbdd9310f00ac6df5b,.,com.cedarsoftware.io.AtomicBooleanTest.testAssignAtomicBoolean,ID,Accepted,https://github.com/jdereg/json-io/pull/301,
+https://github.com/jdereg/json-io,45699f116bdaac9449cc58fbdd9310f00ac6df5b,.,com.cedarsoftware.io.AtomicLongTest.testAssignAtomicLong,ID,DeveloperFixed,,https://github.com/jdereg/json-io/commit/9adaedaf947489856d1bddbad106d87bccdf9713
 https://github.com/jdereg/json-io,0df114821029ecb9bfbd0e3657f2b515c9a85889,.,com.cedarsoftware.io.CollectionTests.testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded,ID,Accepted,https://github.com/jdereg/json-io/pull/301,
 https://github.com/jdereg/json-io,a6f9b6bbf0bd99cd9fa681d7ffeceb90ea87461e,.,com.cedarsoftware.io.MapsTest.testMap,ID,Accepted,https://github.com/jdereg/json-io/pull/302,
 https://github.com/jdereg/json-io,8d46689078710b044c80ff577c486e323d035eb5,.,com.cedarsoftware.io.MapsTest.testReconstituteMap,ID,,,


### PR DESCRIPTION
This PR follows up on this one: https://github.com/TestingResearchIllinois/idoft/pull/1375

One of the ID tests, `com.cedarsoftware.io.AtomicLongTest.testAssignAtomicLong`, is no longer ID due to the deletion of the line of code that caused the flakiness.

I ran NonDex on the commit where the test was moved to the new module path: https://github.com/jdereg/json-io/commit/45699f116bdaac9449cc58fbdd9310f00ac6df5b. The log file can be found here: [mvn-nondex-testAssignAtomicLong-old-commit.log](https://github.com/user-attachments/files/17515638/mvn-nondex-testAssignAtomicLong-old-commit-1729828115.log)

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.cedarsoftware.io.AtomicLongTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.826 s <<< FAILURE! -- in com.cedarsoftware.io.AtomicLongTest
[ERROR] com.cedarsoftware.io.AtomicLongTest.testAssignAtomicLong -- Time elapsed: 0.798 s <<< FAILURE!
java.lang.AssertionError
        at com.cedarsoftware.io.AtomicLongTest.testAssignAtomicLong(AtomicLongTest.java:60)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   AtomicLongTest.testAssignAtomicLong:60
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
```

In the log, we can see that the test failed at `com.cedarsoftware.io.AtomicLongTest.testAssignAtomicLong(AtomicLongTest.java:60)`, which corresponds to [line 60 in commit 45699f1](https://github.com/jdereg/json-io/blob/45699f116bdaac9449cc58fbdd9310f00ac6df5b/src/test/java/com/cedarsoftware/io/AtomicLongTest.java#L60).

However, when running the same test against the latest commit, NonDex no longer detects it as ID. Here's the log with the latest commit: [mvn-nondex-testAssignAtomicLong-latest-commit.log](https://github.com/user-attachments/files/17515702/mvn-nondex-testAssignAtomicLong-lastest-commit-1729828315.log).
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.cedarsoftware.io.AtomicLongTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.336 s - in com.cedarsoftware.io.AtomicLongTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```


Upon review, I found that [this commit](https://github.com/jdereg/json-io/commit/9adaedaf947489856d1bddbad106d87bccdf9713) removed the line that caused the test to be flaky.

Based on this, I think we should add a row for this test and mark it as 'Deleted'.