### PR TITLE
3 DeveloperFixed Pinot

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -3265,10 +3265,10 @@ https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-c
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.ForwardIndexHandlerReloadQueriesTest.testSelectQueries,ID,,,
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.JsonIngestionFromAvroQueriesTest.testJsonPathSelectOnJsonColumn,ID,,,
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.JsonIngestionFromAvroQueriesTest.testSimpleSelectOnJsonColumn,ID,,,
-https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.NullEnabledQueriesTest.testQueriesWithDictDoubleColumn,ID,,,
-https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.NullEnabledQueriesTest.testQueriesWithDictFloatColumn,ID,,,
+https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.NullEnabledQueriesTest.testQueriesWithDictDoubleColumn,ID,DeveloperFixed,,https://github.com/apache/pinot/commit/db0f3dcb73bd338d4b754329679e5f3e4d6bf7e0
+https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.NullEnabledQueriesTest.testQueriesWithDictFloatColumn,ID,DeveloperFixed,,https://github.com/apache/pinot/commit/db0f3dcb73bd338d4b754329679e5f3e4d6bf7e0
 https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.NullEnabledQueriesTest.testQueriesWithNoDictDoubleColumn,ID,,,
-https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.NullEnabledQueriesTest.testQueriesWithNoDictFloatColumn,ID,,,
+https://github.com/apache/pinot,ecf41be2ecd007853c2db19e1c6a038cf356cb9e,pinot-core,org.apache.pinot.queries.NullEnabledQueriesTest.testQueriesWithNoDictFloatColumn,ID,DeveloperFixed,,https://github.com/apache/pinot/commit/db0f3dcb73bd338d4b754329679e5f3e4d6bf7e0
 https://github.com/apache/pinot,f79b618141e07c140663791959d96956ad91d811,pinot-query-planner,org.apache.pinot.query.queries.ResourceBasedQueryPlansTest.testQueryExplainPlansAndQueryPlanConversion,ID,,,fails 21/375 cases
 https://github.com/apache/pinot,f79b618141e07c140663791959d96956ad91d811,pinot-query-planner,org.apache.pinot.query.queries.ResourceBasedQueryPlansTest.testQueryExplainPlansWithExceptions,ID,,,fails 1/38 cases
 https://github.com/apache/pinot,85e413ebe8c80513a8a676fc090b1af0f50861f0,pinot-spi,org.apache.pinot.spi.plugin.PluginManagerTest.testGetPluginsToLoad,ID,Accepted,https://github.com/apache/pinot/pull/9925,


### PR DESCRIPTION
These tests within the Pinot repo passed 100 NonDex runs on commit from June 28, 2023(`db0f3dcb73bd338d4b754329679e5f3e4d6bf7e0`) (all log files are on VM 092):

`NullEnabledQueriesTest#testQueriesWithNoDictFloatColumn`
/home/wtrzas2/pinot/pinot-core/.nondex/ruqUpOnDQjeGCLXJrCmwS9CtJG1oVLYq8k9O03m9xhI=

`NullEnabledQueriesTest#testQueriesWithDictDoubleColumn`
/home/wtrzas2/pinot/pinot-core/.nondex/R0q7ufJd3uADPogCCupueDlHpaEOiXAT3xN6TeawUfs=

`NullEnabledQueriesTest#testQueriesWithDictFloatColumn`
/home/wtrzas2/pinot/pinot-core/.nondex/29wsf1s6OKXf21pUscOi7Qu9AYlGC7Hag4bHvZZ3fo=


These tests failed within the next earlier commit June 14, 2023 (`90dc3a3c566e5d634aa00632993ab86ce0549ba5`), as well as previous commits:
`NullEnabledQueriesTest#testQueriesWithNoDictFloatColumn`
/home/wtrzas2/pinot/pinot-core/.nondex/NGOE62z7DLFuYr4SUcFEdUZKgW6EF2eB8WOoi1NvNpw=

`NullEnabledQueriesTest#testQueriesWithDictDoubleColumn`
/home/wtrzas2/pinot/pinot-core/.nondex/6A7J5+AMGoNhWVksgU49pRLv+w1ewntqc5fHIawUDA=

`NullEnabledQueriesTest#testQueriesWithDictFloatColumn`
/home/wtrzas2/pinot/pinot-core/.nondex/pzVaQznKXdF30CbH+rwszbeW3CqusU85ZDgZujIKww=

