### PR TITLE
Update format_checker to check notes for DeveloperFixed tests

### DIFF
--- a/format_checker/pr_checker.py
+++ b/format_checker/pr_checker.py
@@ -103,7 +103,7 @@ def check_status_consistency(filename, row, i, log):
         else:
             check_pr_link(filename, row, i, log)
 
-    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated", "Deleted"]:
+    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated", "Deleted", "DeveloperFixed"]:
 
         # Should contain a note
         if row["Notes"] == "":
@@ -116,7 +116,7 @@ def check_status_consistency(filename, row, i, log):
                     "Status " + row["Status"] + " should contain a note",
                 )
             # error if no note:
-            if row["Status"] in ["MovedOrRenamed", "Deleted"]:
+            if row["Status"] in ["MovedOrRenamed", "Deleted", "DeveloperFixed"]:
                 log_std_error(filename, log, i, row, "Notes")
 
         # If it contains a note, it should be a valid link


### PR DESCRIPTION
This PR addresses the [feedback](https://github.com/TestingResearchIllinois/idoft/pull/1449#issuecomment-2462960170) provided in #1449. The `format_checker` now enforces `notes` column to be non-empty for `DeveloperFixed` tests.