### PR TITLE
Update py-data.csv for all RepoDeleted repos

### DIFF
--- a/py-data.csv
+++ b/py-data.csv
@@ -32,9 +32,9 @@ https://github.com/alexrudy/supertunnel,4c64e2fedda3382b809a2c3d01c711ec4961f933
 https://github.com/alexrudy/supertunnel,4c64e2fedda3382b809a2c3d01c711ec4961f933,supertunnel/ssh/continuous_test.py::test_ssh_log_line[Host example.com not responding-Action.DISCONNECTED],OD-Brit,Unmaintained,,latest commit 2019/11/21
 https://github.com/aluttik/kitsune,43824cccf46f433a71b30a7febc0e3500b831067,tests/test_kitsune.py::test_kitsune_printer_plain,NIO,Unmaintained,,latest commit 2018/11/19
 https://github.com/aluttik/kitsune,43824cccf46f433a71b30a7febc0e3500b831067,tests/test_kitsune.py::test_kitsune_printer_plain tests/test_kitsune.py::test_kitsune_printer_rainbow,,Unmaintained,,pytest --flake-finder --flake-runs=2;latest commit 2018/11/19
-https://github.com/AshtonUPS/Py-MI-PS,e43c2b4df2b59362c147024840bf541bb767ffd7,src/PyMIPS/tests/register_test.py,NIO,Open,https://github.com/AshtonUPS/Py-MI-PS/pull/23,
-https://github.com/AshtonUPS/Py-MI-PS,2d22327c75bac1b58a4804a61e7a703ecc5ba978,src/PyMIPS/tests/register_test.py::test_setting_to_num,NIO,Opened,https://github.com/AshtonUPS/Py-MI-PS/pull/22,
-https://github.com/AshtonUPS/Py-MI-PS,2d22327c75bac1b58a4804a61e7a703ecc5ba978,src/PyMIPS/tests/register_test.py::test_setting_to_num,OD-Vic,,,
+https://github.com/AshtonUPS/Py-MI-PS,e43c2b4df2b59362c147024840bf541bb767ffd7,src/PyMIPS/tests/register_test.py,NIO,Open,https://github.com/AshtonUPS/Py-MI-PS/pull/23,RepoDeleted
+https://github.com/AshtonUPS/Py-MI-PS,2d22327c75bac1b58a4804a61e7a703ecc5ba978,src/PyMIPS/tests/register_test.py::test_setting_to_num,NIO,Opened,https://github.com/AshtonUPS/Py-MI-PS/pull/22,RepoDeleted
+https://github.com/AshtonUPS/Py-MI-PS,2d22327c75bac1b58a4804a61e7a703ecc5ba978,src/PyMIPS/tests/register_test.py::test_setting_to_num,OD-Vic,RepoDeleted,,
 https://github.com/attzonko/mmpy_bot,4faa19a9e04c75af94c45c24dbd0c9d9ecb867d4,tests/unit_tests/test_scheduler.py::test_add_onetime_job_without_trigger_time,OD-Vic,Deleted,,Deleted in commit 8bba73afdd0dc3ce01c8b0599e59aa5688faf281
 https://github.com/attzonko/mmpy_bot,4faa19a9e04c75af94c45c24dbd0c9d9ecb867d4,tests/unit_tests/test_scheduler.py::test_add_onetime_job_with_trigger_time,OD-Vic,Deleted,,Deleted in commit 8bba73afdd0dc3ce01c8b0599e59aa5688faf281
 https://github.com/AuraiProject/freesia,16834c17725edac74eb50fc5ce2ff1db6f3f4840,tests/test_route.py::RouteTestCase::test_url_match,OD-Brit,Unmaintained,,latest commit 2019/04/30
@@ -336,7 +336,7 @@ https://github.com/eillarra/carbonize,efc89b8a9e44f9d64110406ce70929a9671517c7,t
 https://github.com/eillarra/carbonize,efc89b8a9e44f9d64110406ce70929a9671517c7,tests/test_api.py::TestFootprint::test_flight_two_way,OD-Brit,Unmaintained,,latest commit 2022/04/12
 https://github.com/eillarra/carbonize,891d1d07ca2e9cc48ca5b609da292dce2e574c7e,test_api.py::TestFootprint::test_flight?,OD,Opened,https://github.com/eillarra/carbonize/pull/1,
 https://github.com/eillarra/carbonize,891d1d07ca2e9cc48ca5b609da292dce2e574c7e,test_api.py::TestFootprint::test_flight_two_way?,OD,Opened,https://github.com/eillarra/carbonize/pull/1,
-https://github.com/ElementAI/greensim,f160e8b57d69f6ef469f2e991cc07b7721e08a91,tests/test_sim.py::test_simulator_gc_processes_hanging,OD-Vic,,,
+https://github.com/ElementAI/greensim,f160e8b57d69f6ef469f2e991cc07b7721e08a91,tests/test_sim.py::test_simulator_gc_processes_hanging,OD-Vic,RepoDeleted,,
 https://github.com/EPAENERGYSTAR/epathermostat,98aaf571fe8e15e1a372567776081fd9dae7e872,tests/test_core.py::test_multiple_same_key,NIO,DevelopersDoNotWantFix,https://github.com/EPAENERGYSTAR/epathermostat/pull/33,
 https://github.com/epsagon/epsagon-python,15ab5c9f5c7dda93f546e20aded715f85a1dea3c,tests/test_transports.py::test_httptransport_timeout,UD,RepoArchived,,
 https://github.com/epsagon/epsagon-python,b985d8412848f9a0c98e2f15ae0967a6dba3517f,tests/wrappers/test_python_function.py::test_function_wrapper_function_exception,OD-Vic,RepoArchived,,
@@ -660,7 +660,7 @@ https://github.com/jamesevickery/l293d,c026a9b58769f23d3e999234ba9df30fb021f949,
 https://github.com/JBielan/py_ev,0a2d48235b8ff2268254c151a179a2ece40cbd37,tests/test_py_ev.py::test_reset,OD-Vic,Unmaintained,,latest commit 2019/05/29
 https://github.com/jedie/bootstrap_env,ab68025d8f6b9a17d8feeed83e8aae26e3f28769,bootstrap_env/tests/test_boot.py::BootstrapEnvTestCase::test_setup,NOD,Unmaintained,,latest commit 2019/01/08
 https://github.com/jedie/bootstrap_env,ab68025d8f6b9a17d8feeed83e8aae26e3f28769,bootstrap_env/tests/test_test_utils.py::BootstrapEnvTestCase::test_setup,NOD,Unmaintained,,latest commit 2019/01/08
-https://github.com/jerodg/jgutils,6c8ed6aca37d509af8ce1b57635fad62f1c846b4,jgutils/tests/test_persistentdict.py::TestPersistentDict::test_file_creation2,NOD,RepoArchived,,
+https://github.com/jerodg/jgutils,6c8ed6aca37d509af8ce1b57635fad62f1c846b4,jgutils/tests/test_persistentdict.py::TestPersistentDict::test_file_creation2,NOD,RepoDeleted,,
 https://github.com/JGoutin/compilertools,7b898cb6970f5f25c5356b15a2efd0cb2e54d566,tests/test_build.py::tests_patch___new__,OD-Brit,,,
 https://github.com/JGoutin/compilertools,7b898cb6970f5f25c5356b15a2efd0cb2e54d566,tests/test___init__.py::tests_init,OD-Vic,,,
 https://github.com/jmsv/l293d,e29d7397b4cde4d2d466f018279c2df7d2e84cd9,tests/test_l293d.py::L293DTestCase::test_create_motor_with_force_selection tests/test_l293d.py::L293DTestCase::test_motor_can_be_removed tests/test_l293d.py::L293DTestCase::test_pin_numbering_lock tests/test_l293d.py::L293DTestCase::test_pins_string_list,,Unmaintained,,pytest --flake-finder --flake-runs=2;latest commit 2021/06/19
@@ -941,22 +941,22 @@ https://github.com/opper/pyserverpilot,b6b896fea1155fa95febde84f74e0d2230523ab0,
 https://github.com/opper/pyserverpilot,b6b896fea1155fa95febde84f74e0d2230523ab0,tests/test_app.py::TestApp::test_update_app_validation,OD-Brit,Unmaintained,,latest commit 2021/03/30
 https://github.com/opper/pyserverpilot,b6b896fea1155fa95febde84f74e0d2230523ab0,tests/test_db.py::TestDb::test_get_db,OD-Brit,Unmaintained,,latest commit 2021/03/30
 https://github.com/opper/pyserverpilot,b6b896fea1155fa95febde84f74e0d2230523ab0,tests/test_db.py::TestDb::test_update_db,OD-Brit,Unmaintained,,latest commit 2021/03/30
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_inputs,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_ok,OD-Vic,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_unknown,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskFactory::test_tukio_task_attrs_from_coro,OD-Vic,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskFactory::test_without_tukio_factory,OD-Vic,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskFactory::test_with_tukio_factory,OD-Vic,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskRegistry::test_register_same_name,OD-Vic,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskRegistry::test_valid_registrations,OD-Vic,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_build_from_dict,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_build_from_dict_without_name,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_dump_as_dict,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_task,OD-Vic,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_task_bad_args,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_task_unknown,NOD,,,
-https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_template,NOD,,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_inputs,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_ok,OD-Vic,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_unknown,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskFactory::test_tukio_task_attrs_from_coro,OD-Vic,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskFactory::test_without_tukio_factory,OD-Vic,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskFactory::test_with_tukio_factory,OD-Vic,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskRegistry::test_register_same_name,OD-Vic,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskRegistry::test_valid_registrations,OD-Vic,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_build_from_dict,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_build_from_dict_without_name,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_dump_as_dict,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_task,OD-Vic,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_task_bad_args,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_task_unknown,NOD,RepoDeleted,,
+https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestTaskTemplate::test_new_template,NOD,RepoDeleted,,
 https://github.com/osantana/prettyconf/issues/47,f278b6ac6786f6ab8fe41ffacde0cc1e41cee207,tests/test_commandline.py::test_ignores_not_set_values,OD,,,pytest --randomly-seed=123
 https://github.com/Osirium/vcdriver,2f311df9a73c82b5837d01bac16a10eb4db955eb,test/unit/test_config.py::test_read,NIO,Opened,https://github.com/Osirium/vcdriver/pull/23,
 https://github.com/Osirium/vcdriver,2f311df9a73c82b5837d01bac16a10eb4db955eb,test/unit/test_config.py::test_read,OD-Vic,Unmaintained,,latest commit 2021/01/06


### PR DESCRIPTION
Mark all deleted repos in `py-data.csv` as `RepoDeleted`, addressing [comment](https://github.com/TestingResearchIllinois/idoft/pull/1494#issuecomment-2477938578) provided in #1494.