### PR TITLE
Improve repoArchivedCheck.py handling logic and output message clarity

### DIFF
--- a/auto-update-dataset/python/repoArchivedCheck.py
+++ b/auto-update-dataset/python/repoArchivedCheck.py
@@ -43,12 +43,6 @@ def main():
         my_dict[i[0]].append(line)
         line_number += 1
 
-    # # save urls in file
-    # f = open("pandas_reads_results.txt", "w")
-    # for i in urls:
-    #     f.writelines(i + "\n")
-    # f.close()
-
     archived = []
     anomaly = []
     begin = time.time()
@@ -69,12 +63,11 @@ def main():
         if div and "This repository has been archived by the owner" in div.text:
             archived.append(url)
             print("archived: ", url)
-        # if "archived" in r.text[:len(r.text)]:
-        #     print(url)
     end = time.time()
 
     print("\n===========\n[summary]")
     print("1.total time: ", end-begin, "s")
+    print("")
 
     print("2.repoArchived: ")
     for i in archived:
@@ -96,38 +89,38 @@ def main():
             print("line_number " + str(i[0]) + ":")  # line_number
             print(str(i[1:]).replace("[", "").replace("]", "").replace("\'", "").replace(", ", ",").replace("nan", "").replace("\"", ""))
             print("")
+    print("")
 
     print("3.anomaly:")
     for i in anomaly:
-        print("status code:" + str(i[0]) + ", "),
+        print("status code: " + str(i[0])),
         print("url:", i[1])
         print("[!]details: ")
-        update = []
+        updates = []
         if str(i[0]) == '404':
-            for i in anomaly:
-                for j in my_dict[i[1]]:
-                    if j[status_idx] != "RepoDeleted" and j[notes] != "RepoDeleted":
-                        if pd.isna(j[status_idx]) or j[status_idx] == "":
-                            j[status_idx] = "RepoDeleted"
-                        else:
-                            j[notes] = "RepoDeleted"
-                update.append(j)
-            if not update:
+            for record in my_dict[i[1]]:
+                if record[status_idx] != "RepoDeleted" and record[notes] != "RepoDeleted":
+                    # should mark deleted archived repo as deleted
+                    if pd.isna(record[status_idx]) or record[status_idx] == "" or record[status_idx] == "RepoArchived":
+                        record[status_idx] = "RepoDeleted"
+                    else:
+                        record[notes] = "RepoDeleted"
+                    updates.append(record)
+            if not updates:
                 print("No need to update")
+                print("")
             else:
                 print("[!]Need to Update (Copy the following contents and replace the corresponding line in csv.file)")
-                for j in anomaly:
-                    for i in my_dict[j[1]]:
-                        print("line_number " + str(i[0]) + ":")
-                        print(str(i[1:]).replace("[", "").replace("]", "").replace("\'", "").replace(", ", ",").replace("nan", "").replace("\"", ""))
-                        print("")
+                for update in updates:
+                    print("line_number " + str(update[0]) + ":")
+                    print(str(update[1:]).replace("[", "").replace("]", "").replace("\'", "").replace(", ", ",").replace("nan", "").replace("\"", ""))
+                    print("")
                 print("")
         else:
-            for j in anomaly:
-                for i in my_dict[j[1]]:
-                    print("line_number " + str(i[0]) + ":")
-                    print(str(i[1:]).replace("[", "").replace("]", "").replace("\'", "").replace(", ", ",").replace("nan", "").replace("\"", ""))
-                    print("")
+            for record in my_dict[i[1]]:
+                print("line_number " + str(record[0]) + ":")
+                print(str(record[1:]).replace("[", "").replace("]", "").replace("\'", "").replace(", ", ",").replace("nan", "").replace("\"", ""))
+                print("")
             print("")
 
 


### PR DESCRIPTION
When using [repoArchivedCheck.py](https://github.com/TestingResearchIllinois/idoft/blob/main/auto-update-dataset/python/repoArchivedCheck.py) to check for deleted repos, I encountered several issues affecting readability:

1. The checker outputs suggested changes for all deleted repos for each url with a `404` status code. This is redundant, which would make the output message unnecessarily long and hurt readability.
2. The checker would propose changes for repos that are already marked as `RepoDeleted`, which is unnecessary.
3. For repos that are initially marked as `RepoArchived` but now are deleted, the checker would add `RepoDeleted` status to the `Notes` section, although I think updating the status from `RepoArchived` to `RepoDeleted` would make more sense in this case.

Hence, I propose the following changes in this PR:

1. The checker still shows the url of each deleted repo, but only prints proposed changes for records associated with that url.
2. For records that are already marked as `RepoDeleted`, the checker would no longer propose changes.
3. For deleted repos previously marked as `RepoArchived`, the script now updates the `Status` column to `RepoDeleted`.
4. Remove unnecessary comments in the script.

For example, given the input file, where all repos in the file are deleted:
```
Project URL,SHA Detected,Pytest Test Name (PathToFile::TestClass::TestMethod or PathToFile::TestMethod),Category,Status,PR Link,Notes
https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_inputs,NOD,,,
https://github.com/jerodg/jgutils,6c8ed6aca37d509af8ce1b57635fad62f1c846b4,jgutils/tests/test_persistentdict.py::TestPersistentDict::test_file_creation2,NOD,RepoArchived,,
```

The original checker would output:
```
3.anomaly:
status code:404, 
url: https://github.com/jerodg/jgutils
[!]details: 
[!]Need to Update (Copy the following contents and replace the corresponding line in csv.file)
line_number 5:
https://github.com/jerodg/jgutils,6c8ed6aca37d509af8ce1b57635fad62f1c846b4,jgutils/tests/test_persistentdict.py::TestPersistentDict::test_file_creation2,NOD,RepoArchived,,RepoDeleted

line_number 2:
https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,

line_number 3:
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,

line_number 4:
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_inputs,NOD,RepoDeleted,,


status code:404, 
url: https://github.com/optiflows/tukio
[!]details: 
[!]Need to Update (Copy the following contents and replace the corresponding line in csv.file)
line_number 5:
https://github.com/jerodg/jgutils,6c8ed6aca37d509af8ce1b57635fad62f1c846b4,jgutils/tests/test_persistentdict.py::TestPersistentDict::test_file_creation2,NOD,RepoArchived,,RepoDeleted

line_number 2:
https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,

line_number 3:
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,

line_number 4:
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_inputs,NOD,RepoDeleted,,


status code:404, 
url: https://github.com/surycat/tukio
[!]details: 
[!]Need to Update (Copy the following contents and replace the corresponding line in csv.file)
line_number 5:
https://github.com/jerodg/jgutils,6c8ed6aca37d509af8ce1b57635fad62f1c846b4,jgutils/tests/test_persistentdict.py::TestPersistentDict::test_file_creation2,NOD,RepoArchived,,RepoDeleted

line_number 2:
https://github.com/optiflows/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,

line_number 3:
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_holder,NOD,RepoDeleted,,

line_number 4:
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_inputs,NOD,RepoDeleted,,
```

With the changes, the checker would now output:
```
status code: 404
url: https://github.com/optiflows/tukio
[!]details: 
No need to update

status code: 404
url: https://github.com/jerodg/jgutils
[!]details: 
[!]Need to Update (Copy the following contents and replace the corresponding line in csv.file)
line_number 5:
https://github.com/jerodg/jgutils,6c8ed6aca37d509af8ce1b57635fad62f1c846b4,jgutils/tests/test_persistentdict.py::TestPersistentDict::test_file_creation2,NOD,RepoDeleted,,


status code: 404
url: https://github.com/surycat/tukio
[!]details: 
[!]Need to Update (Copy the following contents and replace the corresponding line in csv.file)
line_number 4:
https://github.com/surycat/tukio,116b35dbceae899d7996b1788449a6e31e3f4512,tests/test_task.py::TestNewTask::test_new_task_bad_inputs,NOD,RepoDeleted,,
```

Let me know if you agree with the changes or if there's anything else you'd like me to change.