### PR TITLE
add tests

### DIFF
--- a/pr-data.csv
+++ b/pr-data.csv
@@ -839,6 +839,8 @@ https://github.com/alibaba/nacos,e77a0bbe0d39a852a52a8d81c20f3fab4f98773d,api,co
 https://github.com/alibaba/nacos,e77a0bbe0d39a852a52a8d81c20f3fab4f98773d,api,com.alibaba.nacos.api.config.remote.response.ConfigChangeBatchListenResponseTest.testSerializeSuccessResponse,ID,Accepted,https://github.com/alibaba/nacos/pull/11373,
 https://github.com/alibaba/nacos,525672272ecb00cd769a13c7b21a8e51cf873f25,api,com.alibaba.nacos.api.naming.pojo.healthcheck.HealthCheckerFactoryTest.testDeserializeExtend,OD-Vic,Accepted,https://github.com/alibaba/nacos/pull/4384,
 https://github.com/alibaba/nacos,e77a0bbe0d39a852a52a8d81c20f3fab4f98773d,api,com.alibaba.nacos.api.remote.ability.ServerRemoteAbilityTest.testSerialize,ID,Accepted,https://github.com/alibaba/nacos/pull/11373,
+https://github.com/alibaba/nacos,aeaaded00a70d7ea11982a0826cef1d7b3203d32,client,com.alibaba.nacos.client.naming.selector.NamingSelectorFactoryTest.testNewMetadataSelector,ID,,,
+https://github.com/alibaba/nacos,aeaaded00a70d7ea11982a0826cef1d7b3203d32,client,com.alibaba.nacos.client.naming.selector.NamingSelectorFactoryTest.testNewMetadataSelector2,ID,,,
 https://github.com/alibaba/nacos,63bd28ae9df8a164f5b8e981f4c533a5bce54eee,http,com.alibaba.nacos.common.http.param.QueryTest.testToQueryUrl,ID,MovedOrRenamed,,
 https://github.com/alibaba/nacos,a0543adafcfed733c0659454e58b3bcd605008a4,common,com.alibaba.nacos.common.http.param.QueryTest.testToQueryUrl,ID,Accepted,https://github.com/alibaba/nacos/pull/7296,
 https://github.com/alibaba/nacos,63bd28ae9df8a164f5b8e981f4c533a5bce54eee,utils,com.alibaba.nacos.common.utils.CollectionUtilsTest.testGetMap3,ID,MovedOrRenamed,,


### PR DESCRIPTION
I found 2 flaky tests in Nacos repo. They can be found as flaky according to Nondex by running the following while in the Nacos directory:
`mvn -pl client edu.illinois:nondex-maven-plugin:2.1.7:nondex  -Dtest=com.alibaba.nacos.client.naming.selector.NamingSelectorFactoryTest#testNewMetadataSelector `
and
`mvn -pl client edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.nacos.client.naming.selector.NamingSelectorFactoryTest#testNewMetadataSelector2 `
Both tests pass when not ran using Nondex and fail under Nondex.

Logs to show this are at logForNacosFoundTests.txt on my vm (031).

Edit: Working on formatting, it will be ready in a bit.