### PR TITLE
Remove trailing whitespace in filter_tests_by_letter.py

### DIFF
--- a/auto-filter-tests-by-letter/filter_tests_by_letter.py
+++ b/auto-filter-tests-by-letter/filter_tests_by_letter.py
@@ -1,8 +1,8 @@
 """
 This script filters rows from a CSV file based on specific criteria.
 
-It identifies rows where the project name (extracted from a URL column) 
-starts with a given letter and where the "Status" column is empty. 
+It identifies rows where the project name (extracted from a URL column)
+starts with a given letter and where the "Status" column is empty.
 The filtered rows are saved to a new CSV file.
 
 Usage:


### PR DESCRIPTION
The fix is based on this error message

```
Run flake8 --extend-ignore=E501
./auto-filter-tests-by-letter/filter_tests_by_letter.py:4:[7](https://github.com/TestingResearchIllinois/idoft/actions/runs/12022473310/job/33514750146#step:6:8)2: W291 trailing whitespace
./auto-filter-tests-by-letter/filter_tests_by_letter.py:5:67: W291 trailing whitespace
Error: Process completed with exit code 1.
```