### PR TITLE
Update an ID Test to MovedOrRenamed with script

### DIFF
--- a/gr-data.csv
+++ b/gr-data.csv
@@ -81,7 +81,7 @@ https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,igni
 https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationListenerTest.testNotifyCurrentConfigurationListeners,ID,,,
 https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationListenerTest.testNotifyListenersOnCurrentConfigWithoutChange,ID,,,
 https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationListenerTest.testNotifyListenersOnNextUpdateConfiguration,ID,,,
-https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationListenerTest.testRemoveStorageRevisionListener,ID,,,
+https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationListenerTest.testRemoveStorageRevisionListener,ID,MovedOrRenamed,,https://github.com/apache/ignite-3/commit/d305b4f153bccf676ef2d71033b11fb8a9de2090
 https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationListenerTest.testStopListen,ID,,,
 https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationRegistryTest.testComplicatedPolymorphicConfig,ID,,,
 https://github.com/apache/ignite-3,8e11db74fa6f10e6026194e69d858ee4735fc70f,ignite-configuration,ConfigurationUtilTest.testSchemaFields,ID,Opened,https://github.com/apache/ignite-3/pull/4557,


### PR DESCRIPTION
Learned and utilized the [auto-check-moved-or-rename script](https://github.com/TestingResearchIllinois/idoft/tree/main/auto-check-moved-or-rename) to identify the commit for this moved test.

The test were moved in [this commit](d305b4f153bccf676ef2d71033b11fb8a9de2090).

I put this test into the test.txt first and copy it and **check_moved_or_rename.sh** script to the root of the repo I wanna test and I ran this to find the commit.
```
./check_moved_or_rename.sh
```