### PR TITLE
Rename all the references of “fury” to “fory"

### DIFF
--- a/format_checker/forked-projects.json
+++ b/format_checker/forked-projects.json
@@ -143,6 +143,7 @@
   "https://github.com/apache/dubbo": "unforked",
   "https://github.com/apache/dubbo-admin": "unforked",
   "https://github.com/apache/flink": "unforked",
+  "https://github.com/apache/fory": "unforked",
   "https://github.com/apache/fury": "unforked",
   "https://github.com/apache/geronimo-batchee": "unforked",
   "https://github.com/apache/gora": "unforked",

--- a/format_checker/pr_checker.py
+++ b/format_checker/pr_checker.py
@@ -54,6 +54,7 @@ data = {
         "Rejected",
         "Skipped",
         "MovedOrRenamed",
+        "RepoRenamed",
         "Claimed",
         "MovedToGradle",
         "FixedOrder",
@@ -104,7 +105,7 @@ def check_status_consistency(filename, row, i, log):
         else:
             check_pr_link(filename, row, i, log)
 
-    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated", "Deleted", "DeveloperFixed"]:
+    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated", "Deleted", "DeveloperFixed", "RepoRenamed"]:
 
         # Should contain a note
         if row["Notes"] == "":
@@ -117,12 +118,14 @@ def check_status_consistency(filename, row, i, log):
                     "Status " + row["Status"] + " should contain a note",
                 )
             # error if no note:
-            if row["Status"] in ["MovedOrRenamed", "Deleted", "DeveloperFixed"]:
+            if row["Status"] in ["MovedOrRenamed", "Deleted", "DeveloperFixed", "RepoRenamed"]:
                 log_std_error(filename, log, i, row, "Notes")
 
         # If it contains a note, it should be a valid link
         else:
-            check_notes(filename, row, i, log)
+            # RepoRenamed notes can be free text
+            if row["Status"] != "RepoRenamed":
+                check_notes(filename, row, i, log)
 
         # Should contain a PR Link
         if row["Status"] == "InspiredAFix":

--- a/pr-data.csv
+++ b/pr-data.csv
@@ -1736,15 +1736,23 @@ https://github.com/apache/flink,e246a05cd898e16758a52335250571e165a5148a,flink-t
 https://github.com/apache/flink,23c9b5ac50d04d28a34a87c78eb2d3331c06b74b,flink-tests,org.apache.flink.test.misc.GenericTypeInfoTest.testSerializerTree,ID,,,
 https://github.com/apache/flink,f91bd772de866a48d65dfcb31d4ef0d1ef2c001e,flink-core,org.apache.flink.types.RowTest.testDeepToString,ID,Opened,https://github.com/apache/flink/pull/17934,
 https://github.com/apache/flink,f91bd772de866a48d65dfcb31d4ef0d1ef2c001e,flink-core,org.apache.flink.types.RowTest.testRowNamed,ID,Opened,https://github.com/apache/flink/pull/17934,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.collection.LazyMapTest.testMap,ID,,,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.ForyCopyTest.mutableObjectCopyTest,ID,,,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.resolver.MetaContextTest.testShareClassDefCompatible,ID,,,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.resolver.MetaContextTest.testShareClassName,ID,,,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.serializer.collection.CollectionSerializersTest.tesPriorityQueueSerializer,ID,,,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.serializer.collection.CollectionSerializersTest.testCollectionFieldSerializers,ID,,,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.serializer.collection.CollectionSerializersTest.testCollectionFieldSerializersCopy,ID,,,
+https://github.com/apache/fory,5f9934e281fde3341c3e9db3b5d3981d08afd85a,fory-core,org.apache.fory.serializer.ProtocolInteroperabilityTest.testComplexCollection,ID,,,
 https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.codegen.ExpressionVisitorTest.testTraverseExpression,ID,Accepted,https://github.com/apache/fury/pull/1968,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.collection.LazyMapTest.testMap,ID,,,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.FuryCopyTest.mutableObjectCopyTest,ID,,,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.resolver.MetaContextTest.testShareClassDefCompatible,ID,,,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.resolver.MetaContextTest.testShareClassName,ID,,,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.collection.CollectionSerializersTest.tesPriorityQueueSerializer,ID,,,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.collection.CollectionSerializersTest.testCollectionFieldSerializers,ID,,,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.collection.CollectionSerializersTest.testCollectionFieldSerializersCopy,ID,,,
-https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.ProtocolInteroperabilityTest.testComplexCollection,ID,,,
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.collection.LazyMapTest.testMap,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.FuryCopyTest.mutableObjectCopyTest,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.resolver.MetaContextTest.testShareClassDefCompatible,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.resolver.MetaContextTest.testShareClassName,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.collection.CollectionSerializersTest.tesPriorityQueueSerializer,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.collection.CollectionSerializersTest.testCollectionFieldSerializers,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.collection.CollectionSerializersTest.testCollectionFieldSerializersCopy,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
+https://github.com/apache/fury,9295e58ae706a3734f6fa80704c41502ba73131e,fury-core,org.apache.fury.serializer.ProtocolInteroperabilityTest.testComplexCollection,ID,RepoRenamed,,Repo was renamed from apache/fury to apache/fory
 https://github.com/apache/geronimo-batchee,0071edabb6b340cc16f8e9d0e17ff25720b4d0fe,tools/cli,org.apache.batchee.cli.MainTest.executions,OD,FixedOrder,,
 https://github.com/apache/gora,6c6b06c916b969352a6757ba7025cc78055fa87a,gora-hbase,org.apache.gora.hbase.store.TestHBaseStore.assertMetadataAnalyzer,NOD,,,
 https://github.com/apache/gora,6c6b06c916b969352a6757ba7025cc78055fa87a,gora-hive,org.apache.gora.hive.store.TestHiveStore.testAutoCreateSchema,ID,,,

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,7 @@ DeveloperWontFix | For tests where developers claimed that they do not want a fi
 DeveloperFixed | For tests where a developer fixed the tests before a PR was made
 Deleted | For tests that can no longer be fixed as the tests have been removed from the repository after the tests were detected
 Rejected | For tests where a PR was rejected/closed as the developers did not think a fix was necessary
+RepoRenamed | For tests where the repository has been renamed. Add this status to the row containing the old repository name, and include a [Note](#adding-notes) explaining what the repository has been renamed to.
 Skipped | For test which was inspected and should not be fixed (e.g., test is annotated with @Ignore). To use this status, please provide some [Notes](#adding-notes) on why the test should be skipped
 MovedOrRenamed | For test that has a different fully-qualified name on two different shas. This status should be added only to the row with the older sha. To use this status, please also provide some [Notes](#adding-notes) on what the test is renamed to
 RepoArchived | For test that is in an archived repo, which is indicated by GitHub in messages such as "This repository has been archived by the owner. It is now read-only."


### PR DESCRIPTION
As requested by [yiming34@illinois.edu](yiming34@illinois.edu). The original repo has been renamed to `fory`.