### PR TITLE
Add Irreproducible status and mark Druid test as Irreproducible

### DIFF
--- a/format_checker/pr_checker.py
+++ b/format_checker/pr_checker.py
@@ -53,6 +53,7 @@ data = {
         "Deleted",
         "Rejected",
         "Skipped",
+        "Irreproducible",
         "MovedOrRenamed",
         "RepoRenamed",
         "Claimed",
@@ -105,7 +106,7 @@ def check_status_consistency(filename, row, i, log):
         else:
             check_pr_link(filename, row, i, log)
 
-    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated", "Deleted", "DeveloperFixed", "RepoRenamed"]:
+    if row["Status"] in ["InspiredAFix", "Skipped", "MovedOrRenamed", "Deprecated", "Deleted", "DeveloperFixed", "RepoRenamed", "Irreproducible"]:
 
         # Should contain a note
         if row["Notes"] == "":
@@ -118,13 +119,13 @@ def check_status_consistency(filename, row, i, log):
                     "Status " + row["Status"] + " should contain a note",
                 )
             # error if no note:
-            if row["Status"] in ["MovedOrRenamed", "Deleted", "DeveloperFixed", "RepoRenamed"]:
+            if row["Status"] in ["MovedOrRenamed", "Deleted", "DeveloperFixed", "RepoRenamed", "Irreproducible"]:
                 log_std_error(filename, log, i, row, "Notes")
 
         # If it contains a note, it should be a valid link
         else:
-            # RepoRenamed notes can be free text
-            if row["Status"] != "RepoRenamed":
+            # RepoRenamed, Irreproducible notes can be free text
+            if row["Status"] not in ["RepoRenamed", "Irreproducible"]:
                 check_notes(filename, row, i, log)
 
         # Should contain a PR Link

--- a/pr-data.csv
+++ b/pr-data.csv
@@ -664,7 +664,7 @@ https://github.com/alibaba/alibabacloud-tairjedis-sdk,f6215930b9e21a5252c95296d9
 https://github.com/alibaba/alibabacloud-tairjedis-sdk,f6215930b9e21a5252c95296d9924b3c4524d9f6,.,com.aliyun.tair.tests.tairzset.TairZsetTest.zrevrank,NOD,,,
 https://github.com/alibaba/alibabacloud-tairjedis-sdk,f6215930b9e21a5252c95296d9924b3c4524d9f6,.,com.aliyun.tair.tests.tairzset.TairZsetTest.zscore,NOD,,,
 https://github.com/alibaba/asyncload,9891e7086bff81ebdd4991435d21b549e48e874d,.,com.alibaba.asyncload.AsyncLoadThreadLocalTest.testInheritableThreadLocalRunnerSet,OD-Vic,Unmaintained,,last commit on 2018-05-15
-https://github.com/alibaba/druid,4ccecebe8da73df3ae22124fc5add3015fd1a8f1,core,com.alibaba.druid.bvt.pool.DruidDataSourceTest_exceptionSorter.test_event_error,ID,,,
+https://github.com/alibaba/druid,4ccecebe8da73df3ae22124fc5add3015fd1a8f1,core,com.alibaba.druid.bvt.pool.DruidDataSourceTest_exceptionSorter.test_event_error,ID,Irreproducible,,Cannot reproduce failure locally
 https://github.com/alibaba/druid,ad05a9293b6be2d5562807698b215b673db0417a,pool,com.alibaba.druid.bvt.pool.DruidDataSourceTest_exceptionSorter.test_event_error,ID,MovedOrRenamed,,https://github.com/alibaba/druid/commit/1e93276be86bcf5f8cf114b08689e37f27da8721
 https://github.com/alibaba/druid,ad05a9293b6be2d5562807698b215b673db0417a,create,com.alibaba.druid.bvt.sql.mysql.create.MySqlCreateDatabaseTest.test_2,ID,Opened,https://github.com/alibaba/druid/pull/4575,
 https://github.com/alibaba/druid,ed00cabc48aa329371bec3b6e5a692510d1f1bb2,core,com.alibaba.druid.bvt.sql.mysql.create.MySqlCreateDatabaseTest.test_3,ID,Opened,https://github.com/alibaba/druid/pull/6240,

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ Deleted | For tests that can no longer be fixed as the tests have been removed f
 Rejected | For tests where a PR was rejected/closed as the developers did not think a fix was necessary
 RepoRenamed | For tests where the repository has been renamed. Add this status to the row containing the old repository name, and include a [Note](#adding-notes) explaining what the repository has been renamed to.
 Skipped | For test which was inspected and should not be fixed (e.g., test is annotated with @Ignore). To use this status, please provide some [Notes](#adding-notes) on why the test should be skipped
+Irreproducible | For tests that cannot be reproduced or rerun. Add this status to the row corresponding to the affected test, and include a short [Note](#adding-notes) indicating that the test result could not be reproduced.
 MovedOrRenamed | For test that has a different fully-qualified name on two different shas. This status should be added only to the row with the older sha. To use this status, please also provide some [Notes](#adding-notes) on what the test is renamed to
 RepoArchived | For test that is in an archived repo, which is indicated by GitHub in messages such as "This repository has been archived by the owner. It is now read-only."
 Deprecated | For test that is in a deprecated repository, which is usually indicated in the project README or description as "Deprecated" or a similar message. To use this status, please also provide some [Notes](#adding-notes) that contain a link to the commit that marks the repository as deprecated. 


### PR DESCRIPTION
Add `Irreproducible` status and update type for 1 alibaba/druid test
- Added `Irreproducible` to allowed statuses in `pr_checker.py`
- Mark `com.alibaba.druid.bvt.pool.DruidDataSourceTest_exceptionSorter.test_event_error` as Irreproducible

