### PR TITLE
add new category TD

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ NDOD | Non-Deterministic Order-Dependent tests that fail non-deterministically b
 NDOI | Non-Deterministic Order-Independent tests that fail non-deterministically but similar failure rates in all orders as defined in our [ISSRE’20 work](http://mir.cs.illinois.edu/winglam/publications/2020/LamETAL20ISSRE.pdf)
 UD | Unknown Dependency tests that pass and fail in a test suite or in isolation
 OSD | Operating System Dependent tests that pass and fail depending on the operating system
+TD | Time-Dependent flaky tests as defined in [FlakeSync](https://utexas.box.com/v/august-shi-ICSE2024)
 TZD | Tests that fail in machines on different time zones, usually failing time-related assertions 
  
 * **Status**: This defines the state the flaky test is in. Only one status may be used at any given time for each flaky test. The accepted status values are:


### PR DESCRIPTION
add new category TD to readme, defined in the paper FlakeSync. The flakiness of such test can be detected using its corresponding repo.