### PR TITLE
Added duplicate key detection forked_projects_util.py

### DIFF
--- a/format_checker/forked_projects_util.py
+++ b/format_checker/forked_projects_util.py
@@ -40,6 +40,20 @@ def is_fp_sorted(data):
     return list1 == list2
 
 
+def find_duplicate_json_keys(file_path):
+    from collections import Counter
+    import re
+    
+    with open(file_path, "r") as f:
+        content = f.read()
+    
+    # Extract all keys using regex: "key": 
+    pattern = r'"([^"]+)"\s*:'
+    keys = re.findall(pattern, content)
+    counter = Counter(keys)
+    return [k for k, v in counter.items() if v > 1]
+
+
 def update_fp(data, file_path):
     sorted_data = dict(sorted(data.items()))
 
@@ -61,8 +75,11 @@ def check_stale_fp(data, file_path, log):
 def run_checks_sort_fp(file_path, log):
     with open(file_path, "r") as file:
         data = json.load(file)
-    if not is_fp_sorted(data):
-        log_esp_error(file_path, log, "Entries are not sorted")
+    dups = find_duplicate_json_keys(file_path)
+    if dups:
+        log_esp_error(file_path, log, f"Duplicate in forked-projects.json keys detected: {dups}")
+    elif not is_fp_sorted(data):
+        log_esp_error(file_path, log, "Entries in forked-projects.json are not sorted")
     else:
         log_info(file_path, log, "There are no changes to be checked")
 


### PR DESCRIPTION
This PR adds a check for duplicate keys in `forked_projects.json`. I added a new function, `find_duplicate_json_keys`, which scans the raw JSON file to detect duplicate keys before it is parsed. I then updated `run_checks_sort_fp` to report an error if any duplicates are found. This helps catch cases where duplicate keys would otherwise be silently overwritten, making the checks more reliable.

**Example error:**
`ERROR: On file format_checker/forked-projects.json: Duplicate in forked-projects.json keys detected: ['https://github.com/apache/incubator-shardingsphere']`